### PR TITLE
Fixed a bug with Browse button in W10

### DIFF
--- a/SecureFolderFS.WinUI/ServiceImplementation/FileExplorerService.cs
+++ b/SecureFolderFS.WinUI/ServiceImplementation/FileExplorerService.cs
@@ -44,6 +44,8 @@ namespace SecureFolderFS.WinUI.ServiceImplementation
 
             WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, MainWindow.Instance!.Hwnd);
 
+            folderPicker.FileTypeFilter.Add("*");
+
             var folder = await folderPicker.PickSingleFolderAsync();
 
             return folder?.Path;


### PR DESCRIPTION
According to the documentation, a filter is needed for folderPicker:

https://docs.microsoft.com/en-us/uwp/api/windows.storage.pickers.folderpicker.picksinglefolderasync?view=winrt-22000

![image](https://user-images.githubusercontent.com/11770760/162579729-36ee6c8f-b9f4-45d8-b668-412cbe9919ff.png)
