### PR TITLE
Implemented file name shortening

### DIFF
--- a/src/Core/SecureFolderFS.Core.Dokany/AppModels/DokanyOptions.cs
+++ b/src/Core/SecureFolderFS.Core.Dokany/AppModels/DokanyOptions.cs
@@ -1,8 +1,8 @@
-﻿using SecureFolderFS.Core.FileSystem.AppModels;
+﻿using System;
+using System.Collections.Generic;
+using SecureFolderFS.Core.FileSystem.AppModels;
 using SecureFolderFS.Shared.Extensions;
 using SecureFolderFS.Storage.VirtualFileSystem;
-using System;
-using System.Collections.Generic;
 
 namespace SecureFolderFS.Core.Dokany.AppModels
 {
@@ -36,6 +36,7 @@ namespace SecureFolderFS.Core.Dokany.AppModels
                 IsCachingFileNames = (bool?)options.Get(nameof(IsCachingFileNames)) ?? true,
                 IsCachingDirectoryIds = (bool?)options.Get(nameof(IsCachingDirectoryIds)) ?? true,
                 RecycleBinSize = (long?)options.Get(nameof(RecycleBinSize)) ?? 0L,
+                ShorteningThreshold = (int?)options.Get(nameof(ShorteningThreshold)) ?? 0,
 
                 // Dokany specific
                 MountPoint = (string?)options.Get(nameof(MountPoint))

--- a/src/Core/SecureFolderFS.Core.Dokany/Callbacks/OnDeviceDokany.cs
+++ b/src/Core/SecureFolderFS.Core.Dokany/Callbacks/OnDeviceDokany.cs
@@ -90,6 +90,9 @@ namespace SecureFolderFS.Core.Dokany.Callbacks
                             {
                             }
 
+                            // Materialize sidecar for the new directory name if shortened
+                            ciphertextPath = GetCiphertextPathForUse(fileName) ?? ciphertextPath;
+
                             // Create directory
                             _ = Directory.CreateDirectory(ciphertextPath);
 
@@ -172,6 +175,10 @@ namespace SecureFolderFS.Core.Dokany.Callbacks
                     if (specifics.Options.IsReadOnly && mode.IsWriteFlag())
                         throw FileSystemExceptions.FileSystemReadOnly;
 
+                    // Materialize sidecar for the new file name if shortened
+                    if (mode is FileMode.CreateNew or FileMode.Create or FileMode.OpenOrCreate)
+                        ciphertextPath = GetCiphertextPathForUse(fileName) ?? ciphertextPath;
+
                     var openAccess = readAccess ? System.IO.FileAccess.Read : System.IO.FileAccess.ReadWrite;
                     if (mode == FileMode.CreateNew && readAccess)
                         openAccess = System.IO.FileAccess.ReadWrite;
@@ -252,6 +259,11 @@ namespace SecureFolderFS.Core.Dokany.Callbacks
                     {
                         NativeRecycleBinHelpers.DeleteOrRecycle(ciphertextPath, specifics, StorableType.File);
                     }
+
+                    // Clean up sidecar after successful delete/recycle
+                    NativePathHelpers.DeleteSidecarFile(
+                        Path.GetFileName(ciphertextPath),
+                        Path.GetDirectoryName(ciphertextPath) ?? string.Empty);
                 }
                 catch (UnauthorizedAccessException)
                 {
@@ -537,7 +549,7 @@ namespace SecureFolderFS.Core.Dokany.Callbacks
         public override NtStatus MoveFile(string oldName, string newName, bool replace, IDokanFileInfo info)
         {
             var oldCiphertextPath = GetCiphertextPath(oldName);
-            var newCiphertextPath = GetCiphertextPath(newName);
+            var newCiphertextPath = GetCiphertextPathForUse(newName);
             var fileNameCombined = $"{oldName} -> {newName}";
 
             if (oldCiphertextPath is null || newCiphertextPath is null)
@@ -564,6 +576,11 @@ namespace SecureFolderFS.Core.Dokany.Callbacks
                         File.Move(oldCiphertextPath, newCiphertextPath);
                     }
 
+                    // Clean up old sidecar after successful move
+                    NativePathHelpers.DeleteSidecarFile(
+                        Path.GetFileName(oldCiphertextPath),
+                        Path.GetDirectoryName(oldCiphertextPath) ?? string.Empty);
+
                     return Trace(DokanResult.Success, fileNameCombined, info);
                 }
                 else if (replace)
@@ -578,6 +595,11 @@ namespace SecureFolderFS.Core.Dokany.Callbacks
                     // File
                     File.Delete(newCiphertextPath);
                     File.Move(oldCiphertextPath, newCiphertextPath);
+
+                    // Clean up old sidecar after successful move
+                    NativePathHelpers.DeleteSidecarFile(
+                        Path.GetFileName(oldCiphertextPath),
+                        Path.GetDirectoryName(oldCiphertextPath) ?? string.Empty);
 
                     return Trace(DokanResult.Success, fileNameCombined, info);
                 }
@@ -823,6 +845,11 @@ namespace SecureFolderFS.Core.Dokany.Callbacks
         protected override string? GetCiphertextPath(string plaintextName)
         {
             return NativePathHelpers.GetCiphertextPath(plaintextName, specifics);
+        }
+
+        private string? GetCiphertextPathForUse(string plaintextName)
+        {
+            return NativePathHelpers.GetCiphertextPathForUse(plaintextName, specifics);
         }
     }
 }

--- a/src/Core/SecureFolderFS.Core.FUSE/AppModels/FuseOptions.cs
+++ b/src/Core/SecureFolderFS.Core.FUSE/AppModels/FuseOptions.cs
@@ -61,6 +61,7 @@ namespace SecureFolderFS.Core.FUSE.AppModels
                 IsCachingFileNames = (bool?)options.Get(nameof(IsCachingFileNames)) ?? true,
                 IsCachingDirectoryIds = (bool?)options.Get(nameof(IsCachingDirectoryIds)) ?? true,
                 RecycleBinSize = (long?)options.Get(nameof(RecycleBinSize)) ?? 0L,
+                ShorteningThreshold = (int?)options.Get(nameof(ShorteningThreshold)) ?? 0,
 
                 // FUSE specific
                 MountPoint = (string?)options.Get(nameof(MountPoint)),

--- a/src/Core/SecureFolderFS.Core.FUSE/Callbacks/OnDeviceFuse.cs
+++ b/src/Core/SecureFolderFS.Core.FUSE/Callbacks/OnDeviceFuse.cs
@@ -1,11 +1,13 @@
-using SecureFolderFS.Core.FileSystem;
-using SecureFolderFS.Core.FileSystem.Helpers.Paths;
-using SecureFolderFS.Core.FileSystem.Helpers.Paths.Native;
-using SecureFolderFS.Core.FUSE.OpenHandles;
-using SecureFolderFS.Core.FUSE.UnsafeNative;
 using System.Runtime.CompilerServices;
 using System.Text;
+using OwlCore.Storage;
+using SecureFolderFS.Core.FileSystem;
+using SecureFolderFS.Core.FileSystem.Helpers.Paths;
 using SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract;
+using SecureFolderFS.Core.FileSystem.Helpers.Paths.Native;
+using SecureFolderFS.Core.FileSystem.Helpers.RecycleBin.Native;
+using SecureFolderFS.Core.FUSE.OpenHandles;
+using SecureFolderFS.Core.FUSE.UnsafeNative;
 using Tmds.Fuse;
 using Tmds.Linux;
 using static SecureFolderFS.Core.FUSE.UnsafeNative.UnsafeNativeApis;
@@ -65,7 +67,7 @@ namespace SecureFolderFS.Core.FUSE.Callbacks
             if (FuseOptions!.IsReadOnly)
                 return -EROFS;
 
-            var ciphertextPath = GetCiphertextPath(path);
+            var ciphertextPath = GetCiphertextPathForUse(path);
             if (ciphertextPath is null)
                 return -ENOENT;
 
@@ -259,7 +261,7 @@ namespace SecureFolderFS.Core.FUSE.Callbacks
             if (FuseOptions!.IsReadOnly)
                 return -EROFS;
 
-            var ciphertextPath = GetCiphertextPath(path);
+            var ciphertextPath = GetCiphertextPathForUse(path);
             if (ciphertextPath is null)
                 return -ENOENT;
 
@@ -410,7 +412,7 @@ namespace SecureFolderFS.Core.FUSE.Callbacks
                 return -EROFS;
 
             var ciphertextPath = GetCiphertextPath(path);
-            var newCiphertextPath = GetCiphertextPath(newPath);
+            var newCiphertextPath = GetCiphertextPathForUse(newPath);
             if (ciphertextPath is null || newCiphertextPath is null)
                 return -ENOENT;
 
@@ -421,10 +423,15 @@ namespace SecureFolderFS.Core.FUSE.Callbacks
                     return -errno;
             }
 
+            // Clean up old sidecar after successful rename
+            NativePathHelpers.DeleteSidecarFile(
+                Path.GetFileName(ciphertextPath),
+                Path.GetDirectoryName(ciphertextPath) ?? string.Empty);
+
             return 0;
         }
 
-        public override unsafe int RmDir(ReadOnlySpan<byte> path)
+        public override int RmDir(ReadOnlySpan<byte> path)
         {
             if (FuseOptions!.IsReadOnly)
                 return -EROFS;
@@ -437,16 +444,21 @@ namespace SecureFolderFS.Core.FUSE.Callbacks
                 return -ENOTEMPTY;
 
             var directoryIdPath = Path.Combine(ciphertextPath, FileSystem.Constants.Names.DIRECTORY_ID_FILENAME);
-
-            // Remove DirectoryID
-            File.Delete(directoryIdPath);
             specifics.DirectoryIdCache.CacheRemove(directoryIdPath);
 
-            fixed (byte *ciphertextPathPtr = Encoding.UTF8.GetBytes(ciphertextPath))
+            try
             {
-                if (rmdir(ciphertextPathPtr) == -1)
-                    return -errno;
+                NativeRecycleBinHelpers.DeleteOrRecycle(ciphertextPath, specifics, StorableType.Folder);
             }
+            catch
+            {
+                return -EIO;
+            }
+
+            // Clean up sidecar after successful delete/recycle
+            NativePathHelpers.DeleteSidecarFile(
+                Path.GetFileName(ciphertextPath),
+                Path.GetDirectoryName(ciphertextPath) ?? string.Empty);
 
             return 0;
         }
@@ -529,7 +541,7 @@ namespace SecureFolderFS.Core.FUSE.Callbacks
         /// <remarks>
         /// This method is also responsible for file deletion.
         /// </remarks>
-        public override unsafe int Unlink(ReadOnlySpan<byte> path)
+        public override int Unlink(ReadOnlySpan<byte> path)
         {
             if (FuseOptions!.IsReadOnly)
                 return -EROFS;
@@ -541,11 +553,19 @@ namespace SecureFolderFS.Core.FUSE.Callbacks
             if (Directory.Exists(ciphertextPath))
                 return -EISDIR;
 
-            fixed (byte *ciphertextPathPtr = Encoding.UTF8.GetBytes(ciphertextPath))
+            try
             {
-                if (unlink(ciphertextPathPtr) == -1)
-                    return -errno;
+                NativeRecycleBinHelpers.DeleteOrRecycle(ciphertextPath, specifics, StorableType.File);
             }
+            catch
+            {
+                return -EIO;
+            }
+
+            // Clean up sidecar after successful delete/recycle
+            NativePathHelpers.DeleteSidecarFile(
+                Path.GetFileName(ciphertextPath),
+                Path.GetDirectoryName(ciphertextPath) ?? string.Empty);
 
             return 0;
         }
@@ -569,7 +589,7 @@ namespace SecureFolderFS.Core.FUSE.Callbacks
                         return -errno;
 
                     var result = futimens(*(int*)fd, times);
-                    UnsafeNativeApis.CloseDir(fd);
+                    CloseDir(fd);
 
                     if (result == -1)
                         return -errno;
@@ -614,12 +634,21 @@ namespace SecureFolderFS.Core.FUSE.Callbacks
             return buffer.Length;
         }
 
-        protected override unsafe string? GetCiphertextPath(ReadOnlySpan<byte> plaintextName)
+        protected override unsafe string? GetCiphertextPath(ReadOnlySpan<byte> nativePlaintextName)
         {
-            fixed (byte *plaintextNamePtr = plaintextName)
+            fixed (byte *plaintextNamePtr = nativePlaintextName)
             {
                 var directoryId = new byte[FileSystem.Constants.DIRECTORY_ID_SIZE];
-                return NativePathHelpers.GetCiphertextPath(Encoding.UTF8.GetString(plaintextNamePtr, plaintextName.Length), specifics, directoryId);
+                return NativePathHelpers.GetCiphertextPath(Encoding.UTF8.GetString(plaintextNamePtr, nativePlaintextName.Length), specifics, directoryId);
+            }
+        }
+
+        private unsafe string? GetCiphertextPathForUse(ReadOnlySpan<byte> nativePlaintextName)
+        {
+            fixed (byte *plaintextNamePtr = nativePlaintextName)
+            {
+                var directoryId = new byte[FileSystem.Constants.DIRECTORY_ID_SIZE];
+                return NativePathHelpers.GetCiphertextPathForUse(Encoding.UTF8.GetString(plaintextNamePtr, nativePlaintextName.Length), specifics, directoryId);
             }
         }
     }

--- a/src/Core/SecureFolderFS.Core.FUSE/Callbacks/OnDeviceFuse.cs
+++ b/src/Core/SecureFolderFS.Core.FUSE/Callbacks/OnDeviceFuse.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using OwlCore.Storage;
 using SecureFolderFS.Core.FileSystem;
+using SecureFolderFS.Core.FileSystem.Helpers;
 using SecureFolderFS.Core.FileSystem.Helpers.Paths;
 using SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract;
 using SecureFolderFS.Core.FileSystem.Helpers.Paths.Native;
@@ -450,6 +451,22 @@ namespace SecureFolderFS.Core.FUSE.Callbacks
             {
                 NativeRecycleBinHelpers.DeleteOrRecycle(ciphertextPath, specifics, StorableType.Folder);
             }
+            catch (FileNotFoundException)
+            {
+                return -ENOENT;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return -ENOENT;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return -EACCES;
+            }
+            catch (IOException ioEx) when (ErrorHandlingHelpers.IsDiskFullException(ioEx))
+            {
+                return -ENOSPC;
+            }
             catch
             {
                 return -EIO;
@@ -556,6 +573,22 @@ namespace SecureFolderFS.Core.FUSE.Callbacks
             try
             {
                 NativeRecycleBinHelpers.DeleteOrRecycle(ciphertextPath, specifics, StorableType.File);
+            }
+            catch (FileNotFoundException)
+            {
+                return -ENOENT;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return -ENOENT;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return -EACCES;
+            }
+            catch (IOException ioEx) when (ErrorHandlingHelpers.IsDiskFullException(ioEx))
+            {
+                return -ENOSPC;
             }
             catch
             {

--- a/src/Core/SecureFolderFS.Core.FileSystem/Constants.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Constants.cs
@@ -18,6 +18,8 @@
         public static class Names
         {
             public const string ENCRYPTED_FILE_EXTENSION = ".sffs";
+            public const string SHORTENED_FILE_EXTENSION = ".sffsn";
+            public const string SIDECAR_FILE_EXTENSION = ".sffsi";
             public const string DIRECTORY_ID_FILENAME = "dirid.iv";
             public const string RECYCLE_BIN_NAME = "recycle_bin";
             public const string RECYCLE_BIN_CONFIGURATION_FILENAME = "recycle_bin.cfg";

--- a/src/Core/SecureFolderFS.Core.FileSystem/Exceptions/OrphanSidecarException.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Exceptions/OrphanSidecarException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace SecureFolderFS.Core.FileSystem.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when a sidecar file (.sffsi) exists without a matching shortened file (.sffsn).
+    /// </summary>
+    public sealed class OrphanSidecarException : Exception
+    {
+        public OrphanSidecarException(string sidecarName)
+            : base($"Orphan sidecar file has no matching shortened file: {sidecarName}")
+        {
+        }
+    }
+}

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Health/HealthHelpers.Directory.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Health/HealthHelpers.Directory.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using OwlCore.Storage;
-using SecureFolderFS.Core.Cryptography;
 using SecureFolderFS.Core.FileSystem.Helpers.Paths;
 using SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract;
 using SecureFolderFS.Shared.ComponentModel;
@@ -15,10 +14,10 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Health
 {
     public static partial class HealthHelpers
     {
-        public static async Task<IResult> RepairDirectoryAsync(IFolder affected, Security security, CancellationToken cancellationToken)
+        public static async Task<IResult> RepairDirectoryAsync(IFolder affected, FileSystemSpecifics specifics, CancellationToken cancellationToken)
         {
             // Return success if no encryption is used
-            if (security.NameCrypt is null)
+            if (specifics.Security.NameCrypt is null)
                 return Result.Success;
 
             if (affected is not IRenamableFolder renamableFolder)
@@ -39,9 +38,15 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Health
                     if (PathHelpers.IsCoreName(item.Name))
                         continue;
 
-                    // Encrypt a new name and rename
-                    var encryptedName = AbstractPathHelpers.EncryptNewName(item.Name, directoryId, security);
+                    // Remember old name for sidecar cleanup
+                    var oldName = item.Name;
+
+                    // Encrypt a new name (writes sidecar if shortening applies) and rename
+                    var encryptedName = await AbstractPathHelpers.EncryptNewNameForUseAsync(item.Name, directoryId, affected, specifics, cancellationToken);
                     _ = await renamableFolder.RenameAsync(item, encryptedName, cancellationToken);
+
+                    // Clean up old sidecar if the previous name was shortened
+                    await AbstractPathHelpers.DeleteSidecarFileAsync(oldName, renamableFolder, cancellationToken);
                 }
 
                 return Result.Success;

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Health/HealthHelpers.Name.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Health/HealthHelpers.Name.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using OwlCore.Storage;
-using SecureFolderFS.Core.Cryptography;
 using SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract;
 using SecureFolderFS.Shared.ComponentModel;
 using SecureFolderFS.Shared.Helpers;
@@ -15,45 +14,45 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Health
     {
         public static async Task<IResult> RepairNameAsync(IStorableChild affected, FileSystemSpecifics specifics, string newName, CancellationToken cancellationToken)
         {
-            var repairResult = await RepairNameAsync(affected, specifics.Security, specifics.ContentFolder, newName, cancellationToken);
-            if (!repairResult.Successful || !specifics.CiphertextFileNameCache.IsAvailable)
-                return repairResult;
-
-            // Update cache
-            await SafetyHelpers.NoFailureAsync(async () =>
-            {
-                var parent = await affected.GetParentAsync(cancellationToken);
-                if (parent is null)
-                    return;
-
-                var directoryId = AbstractPathHelpers.AllocateDirectoryId(specifics.Security);
-                var isAllocated = await AbstractPathHelpers.GetDirectoryIdAsync(parent, specifics, directoryId, cancellationToken);
-                specifics.CiphertextFileNameCache.CacheRemove(new(isAllocated ? directoryId : [], affected.Name));
-            });
-
-            return repairResult;
-        }
-
-        private static async Task<IResult> RepairNameAsync(IStorableChild affected, Security security, IFolder contentFolder, string newName, CancellationToken cancellationToken)
-        {
             // Return success if no encryption is used
-            if (security.NameCrypt is null)
+            if (specifics.Security.NameCrypt is null)
                 return Result.Success;
 
             try
             {
-                // Get Directory ID
+                // Get parent folder
                 var parentFolder = await affected.GetParentAsync(cancellationToken);
                 if (parentFolder is not IRenamableFolder renamableFolder)
                     return Result.Failure(FolderNotRenamable);
 
-                // Encrypt new name and rename
-                var encryptedName = await AbstractPathHelpers.EncryptNameAsync(newName, parentFolder, contentFolder, security, cancellationToken);
+                // Remember old name for sidecar cleanup
+                var oldName = affected.Name;
+
+                // Encrypt new name (writes sidecar if shortening applies) and rename
+                var encryptedName = await AbstractPathHelpers.EncryptNameForUseAsync(newName, parentFolder, specifics, cancellationToken);
                 _ = await renamableFolder.RenameAsync(affected, encryptedName, cancellationToken);
+
+                // Clean up old sidecar if the previous name was shortened
+                await AbstractPathHelpers.DeleteSidecarFileAsync(oldName, renamableFolder, cancellationToken);
             }
             catch (Exception ex)
             {
                 return Result.Failure(ex);
+            }
+
+            // Update cache
+            if (specifics.CiphertextFileNameCache.IsAvailable)
+            {
+                await SafetyHelpers.NoFailureAsync(async () =>
+                {
+                    var parent = await affected.GetParentAsync(cancellationToken);
+                    if (parent is null)
+                        return;
+
+                    var directoryId = AbstractPathHelpers.AllocateDirectoryId(specifics.Security);
+                    var isAllocated = await AbstractPathHelpers.GetDirectoryIdAsync(parent, specifics, directoryId, cancellationToken);
+                    specifics.CiphertextFileNameCache.CacheRemove(new(isAllocated ? directoryId : [], affected.Name));
+                });
             }
 
             return Result.Success;

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Health/HealthHelpers.Shortening.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Health/HealthHelpers.Shortening.cs
@@ -38,7 +38,7 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Health
 
             foreach (var sidecar in sidecars)
             {
-                // Derive the expected companion: replace .sffsi → .sffsn
+                // Derive the expected companion (replace .sffsi with .sffsn)
                 var baseName = sidecar.Name[..^Constants.Names.SIDECAR_FILE_EXTENSION.Length];
                 var expectedCompanion = baseName + Constants.Names.SHORTENED_FILE_EXTENSION;
 

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Health/HealthHelpers.Sidecar.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Health/HealthHelpers.Sidecar.cs
@@ -28,7 +28,7 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Health
             var shortenedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var sidecars = new List<IStorableChild>();
 
-            await foreach (var item in folder.GetItemsAsync(StorableType.File, cancellationToken))
+            await foreach (var item in folder.GetItemsAsync(StorableType.All, cancellationToken))
             {
                 if (AbstractPathHelpers.IsSidecarName(item.Name))
                     sidecars.Add(item);

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Health/HealthHelpers.Sidecar.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Health/HealthHelpers.Sidecar.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using OwlCore.Storage;
+using SecureFolderFS.Core.FileSystem.Exceptions;
+using SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract;
+using SecureFolderFS.Shared.ComponentModel;
+using SecureFolderFS.Shared.Models;
+
+namespace SecureFolderFS.Core.FileSystem.Helpers.Health
+{
+    public static partial class HealthHelpers
+    {
+        /// <summary>
+        /// Detects orphan sidecar files in the specified folder and reports them as issues.
+        /// An orphan sidecar is a <c>.sffsi</c> file with no matching <c>.sffsn</c> companion.
+        /// </summary>
+        /// <param name="folder">The folder to scan for orphan sidecars.</param>
+        /// <param name="reporter">The progress reporter for reporting detected issues.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that cancels this action.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public static async Task DetectOrphanSidecarsAsync(IFolder folder, IProgress<IResult>? reporter, CancellationToken cancellationToken = default)
+        {
+            if (reporter is null)
+                return;
+
+            var shortenedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var sidecars = new List<IStorableChild>();
+
+            await foreach (var item in folder.GetItemsAsync(StorableType.File, cancellationToken))
+            {
+                if (AbstractPathHelpers.IsSidecarName(item.Name))
+                    sidecars.Add(item);
+                else if (item.Name.EndsWith(Constants.Names.SHORTENED_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase))
+                    shortenedNames.Add(item.Name);
+            }
+
+            foreach (var sidecar in sidecars)
+            {
+                // Derive the expected companion: replace .sffsi → .sffsn
+                var baseName = sidecar.Name[..^Constants.Names.SIDECAR_FILE_EXTENSION.Length];
+                var expectedCompanion = baseName + Constants.Names.SHORTENED_FILE_EXTENSION;
+
+                if (!shortenedNames.Contains(expectedCompanion))
+                    reporter.Report(Result<IStorable>.Failure(sidecar, new OrphanSidecarException(sidecar.Name)));
+            }
+        }
+
+        /// <summary>
+        /// Deletes an orphan sidecar file.
+        /// </summary>
+        /// <param name="sidecar">The orphan sidecar file to delete.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that cancels this action.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public static async Task<IResult> DeleteOrphanSidecarAsync(IStorableChild sidecar, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                if (sidecar is not IChildFile childFile)
+                    return Result.Failure(new InvalidOperationException("Sidecar is not a child file."));
+
+                var parent = await childFile.GetParentAsync(cancellationToken);
+                if (parent is not IModifiableFolder modifiableFolder)
+                    return Result.Failure(new InvalidOperationException("Parent folder does not support deletion."));
+
+                await modifiableFolder.DeleteAsync(childFile, cancellationToken);
+                return Result.Success;
+            }
+            catch (Exception ex)
+            {
+                return Result.Failure(ex);
+            }
+        }
+    }
+}

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Names.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Names.cs
@@ -168,6 +168,31 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
             return security.NameCrypt.EncryptName(plaintextName, newDirectoryId) + Constants.Names.ENCRYPTED_FILE_EXTENSION;
         }
 
+        /// <summary>
+        /// Encrypts a plaintext name using the specified Directory ID and materializes it, writing a sidecar file if shortening applies.
+        /// </summary>
+        /// <param name="plaintextName">The original plaintext name to encrypt.</param>
+        /// <param name="newDirectoryId">A new Directory ID used for encryption.</param>
+        /// <param name="ciphertextParentFolder">The ciphertext parent folder where the sidecar will be written if needed.</param>
+        /// <param name="specifics">The <see cref="FileSystemSpecifics"/> instance associated with the item.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that cancels this action.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation. Value is an encrypted name with the appropriate file extension appended.</returns>
+        public static async Task<string> EncryptNewNameForUseAsync(string plaintextName, byte[] newDirectoryId, IFolder ciphertextParentFolder, FileSystemSpecifics specifics, CancellationToken cancellationToken = default)
+        {
+            if (specifics.Security.NameCrypt is null)
+                return plaintextName;
+
+            var encryptedName = specifics.Security.NameCrypt.EncryptName(plaintextName, newDirectoryId) + Constants.Names.ENCRYPTED_FILE_EXTENSION;
+            if (specifics.Options.ShorteningThreshold > 0 && encryptedName.Length >= specifics.Options.ShorteningThreshold)
+            {
+                var shortenedBase = ComputeShortenedNameBase(encryptedName);
+                await WriteSidecarAsync(ciphertextParentFolder, shortenedBase, encryptedName, cancellationToken);
+                return shortenedBase + Constants.Names.SHORTENED_FILE_EXTENSION;
+            }
+
+            return encryptedName;
+        }
+
         /// <inheritdoc cref="DecryptNameAsync(string,OwlCore.Storage.IFolder,SecureFolderFS.Core.FileSystem.FileSystemSpecifics,System.Byte[],System.Threading.CancellationToken)"/>
         public static async Task<string?> DecryptNameAsync(string ciphertextName, IFolder ciphertextParentFolder,
             FileSystemSpecifics specifics, CancellationToken cancellationToken = default)

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Names.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Names.cs
@@ -9,6 +9,8 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
 {
     public static partial class AbstractPathHelpers
     {
+        #region Encrypt Name Non-Materialized
+
         /// <inheritdoc cref="EncryptNameAsync(string,OwlCore.Storage.IFolder,SecureFolderFS.Core.FileSystem.FileSystemSpecifics,System.Byte[],System.Threading.CancellationToken)"/>
         public static async Task<string> EncryptNameAsync(string plaintextName, IFolder ciphertextParentFolder,
             FileSystemSpecifics specifics, CancellationToken cancellationToken = default)
@@ -62,6 +64,81 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
             return security.NameCrypt.EncryptName(plaintextName, result ? directoryId : ReadOnlySpan<byte>.Empty) + Constants.Names.ENCRYPTED_FILE_EXTENSION;
         }
 
+        #endregion
+
+        #region Encrypt Name Materialized
+
+        /// <inheritdoc cref="EncryptNameForUseAsync(string,OwlCore.Storage.IFolder,SecureFolderFS.Core.FileSystem.FileSystemSpecifics,System.Byte[],System.Threading.CancellationToken)"/>
+        public static async Task<string> EncryptNameForUseAsync(string plaintextName, IFolder ciphertextParentFolder,
+            FileSystemSpecifics specifics, CancellationToken cancellationToken = default)
+        {
+            if (specifics.Security.NameCrypt is null)
+                return plaintextName;
+
+            var directoryId = AllocateDirectoryId(specifics.Security, plaintextName);
+            return await EncryptNameForUseAsync(plaintextName, ciphertextParentFolder, specifics, directoryId, cancellationToken);
+        }
+
+        /// <summary>
+        /// Encrypts the provided <paramref name="plaintextName"/> and materializes it.
+        /// </summary>
+        /// <param name="plaintextName">The name to encrypt.</param>
+        /// <param name="ciphertextParentFolder">The ciphertext parent folder.</param>
+        /// <param name="specifics">The <see cref="FileSystemSpecifics"/> instance associated with the item.</param>
+        /// <param name="expendableDirectoryId">A buffer of size <see cref="Constants.DIRECTORY_ID_SIZE"/> which will be used to hold the Directory ID data.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that cancels this action.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation. Value is an encrypted name with the appropriate file extension appended.</returns>
+        public static async Task<string> EncryptNameForUseAsync(string plaintextName, IFolder ciphertextParentFolder,
+            FileSystemSpecifics specifics, byte[]? expendableDirectoryId = null, CancellationToken cancellationToken = default)
+        {
+            if (specifics.Security.NameCrypt is null)
+                return plaintextName;
+
+            expendableDirectoryId ??= AllocateDirectoryId(specifics.Security, plaintextName);
+            var result = await GetDirectoryIdAsync(ciphertextParentFolder, specifics, expendableDirectoryId, cancellationToken);
+
+            var encryptedName = specifics.Security.NameCrypt.EncryptName(plaintextName, result ? expendableDirectoryId : ReadOnlySpan<byte>.Empty) + Constants.Names.ENCRYPTED_FILE_EXTENSION;
+            if (SHORTENING_THRESHOLD > 0 && encryptedName.Length >= SHORTENING_THRESHOLD)
+            {
+                var shortenedBase = ComputeShortenedNameBase(encryptedName);
+                await WriteSidecarAsync(ciphertextParentFolder, shortenedBase, encryptedName, cancellationToken);
+                return shortenedBase + Constants.Names.SHORTENED_FILE_EXTENSION;
+            }
+
+            return encryptedName;
+        }
+
+        /// <summary>
+        /// Encrypts the provided <paramref name="plaintextName"/> and materializes it.
+        /// </summary>
+        /// <param name="plaintextName">The name to encrypt.</param>
+        /// <param name="ciphertextParentFolder">The ciphertext parent folder.</param>
+        /// <param name="contentFolder">The content folder.</param>
+        /// <param name="security">The <see cref="Security"/> instance associated with the item.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that cancels this action.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation. Value is an encrypted name with the appropriate file extension appended.</returns>
+        public static async Task<string> EncryptNameForUseAsync(string plaintextName, IFolder ciphertextParentFolder, IFolder contentFolder,
+            Security security, CancellationToken cancellationToken = default)
+        {
+            if (security.NameCrypt is null)
+                return plaintextName;
+
+            var directoryId = AllocateDirectoryId(security, plaintextName);
+            var result = await GetDirectoryIdAsync(ciphertextParentFolder, contentFolder, directoryId, cancellationToken);
+
+            var encryptedName = security.NameCrypt.EncryptName(plaintextName, result ? directoryId : ReadOnlySpan<byte>.Empty) + Constants.Names.ENCRYPTED_FILE_EXTENSION;
+            if (SHORTENING_THRESHOLD > 0 && encryptedName.Length >= SHORTENING_THRESHOLD)
+            {
+                var shortenedBase = ComputeShortenedNameBase(encryptedName);
+                await WriteSidecarAsync(ciphertextParentFolder, shortenedBase, encryptedName, cancellationToken);
+                return shortenedBase + Constants.Names.SHORTENED_FILE_EXTENSION;
+            }
+
+            return encryptedName;
+        }
+
+        #endregion
+
         /// <summary>
         /// Encrypts a plaintext name using the specified Directory ID and security parameters.
         /// </summary>
@@ -103,8 +180,23 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
             if (specifics.Security.NameCrypt is null)
                 return ciphertextName;
 
+            // Sidecar files are internal bookkeeping - they have no plaintext name
+            if (IsSidecarName(ciphertextName))
+                return null;
+
             try
             {
+                // Resolve shortened names to their full ciphertext name via the paired sidecar
+                if (ciphertextName.EndsWith(Constants.Names.SHORTENED_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase))
+                {
+                    var shortenedBase = RemoveShortenedExtension(ciphertextName).ToString();
+                    var resolvedName = await ReadSidecarAsync(ciphertextParentFolder, shortenedBase, cancellationToken);
+                    if (resolvedName is null)
+                        return null;
+
+                    ciphertextName = resolvedName;
+                }
+
                 expendableDirectoryId ??= AllocateDirectoryId(specifics.Security, ciphertextName);
                 var result = await GetDirectoryIdAsync(ciphertextParentFolder, specifics, expendableDirectoryId, cancellationToken);
 

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Names.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Names.cs
@@ -110,6 +110,49 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
 
         #endregion
 
+        #region Encrypt Name Discoverability
+
+        /// <inheritdoc cref="EncryptNameForDiscoveryAsync(string,OwlCore.Storage.IFolder,SecureFolderFS.Core.FileSystem.FileSystemSpecifics,System.Byte[],System.Threading.CancellationToken)"/>
+        public static async Task<string> EncryptNameForDiscoveryAsync(string plaintextName, IFolder ciphertextParentFolder,
+            FileSystemSpecifics specifics, CancellationToken cancellationToken = default)
+        {
+            if (specifics.Security.NameCrypt is null)
+                return plaintextName;
+
+            var directoryId = AllocateDirectoryId(specifics.Security, plaintextName);
+            return await EncryptNameForDiscoveryAsync(plaintextName, ciphertextParentFolder, specifics, directoryId, cancellationToken);
+        }
+
+        /// <summary>
+        /// Encrypts the provided <paramref name="plaintextName"/> and discovers potential shortening branch.
+        /// </summary>
+        /// <param name="plaintextName">The name to encrypt.</param>
+        /// <param name="ciphertextParentFolder">The ciphertext parent folder.</param>
+        /// <param name="specifics">The <see cref="FileSystemSpecifics"/> instance associated with the item.</param>
+        /// <param name="expendableDirectoryId">A buffer of size <see cref="Constants.DIRECTORY_ID_SIZE"/> which will be used to hold the Directory ID data.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that cancels this action.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation. Value is an encrypted name with the appropriate file extension appended.</returns>
+        public static async Task<string> EncryptNameForDiscoveryAsync(string plaintextName, IFolder ciphertextParentFolder,
+            FileSystemSpecifics specifics, byte[]? expendableDirectoryId = null, CancellationToken cancellationToken = default)
+        {
+            if (specifics.Security.NameCrypt is null)
+                return plaintextName;
+
+            expendableDirectoryId ??= AllocateDirectoryId(specifics.Security, plaintextName);
+            var result = await GetDirectoryIdAsync(ciphertextParentFolder, specifics, expendableDirectoryId, cancellationToken);
+
+            var encryptedName = specifics.Security.NameCrypt.EncryptName(plaintextName, result ? expendableDirectoryId : ReadOnlySpan<byte>.Empty) + Constants.Names.ENCRYPTED_FILE_EXTENSION;
+            if (specifics.Options.ShorteningThreshold > 0 && encryptedName.Length >= specifics.Options.ShorteningThreshold)
+            {
+                var shortenedBase = ComputeShortenedNameBase(encryptedName);
+                return shortenedBase + Constants.Names.SHORTENED_FILE_EXTENSION;
+            }
+
+            return encryptedName;
+        }
+
+        #endregion
+
         /// <summary>
         /// Encrypts a plaintext name using the specified Directory ID and security parameters.
         /// </summary>

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Names.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Names.cs
@@ -98,36 +98,7 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
             var result = await GetDirectoryIdAsync(ciphertextParentFolder, specifics, expendableDirectoryId, cancellationToken);
 
             var encryptedName = specifics.Security.NameCrypt.EncryptName(plaintextName, result ? expendableDirectoryId : ReadOnlySpan<byte>.Empty) + Constants.Names.ENCRYPTED_FILE_EXTENSION;
-            if (SHORTENING_THRESHOLD > 0 && encryptedName.Length >= SHORTENING_THRESHOLD)
-            {
-                var shortenedBase = ComputeShortenedNameBase(encryptedName);
-                await WriteSidecarAsync(ciphertextParentFolder, shortenedBase, encryptedName, cancellationToken);
-                return shortenedBase + Constants.Names.SHORTENED_FILE_EXTENSION;
-            }
-
-            return encryptedName;
-        }
-
-        /// <summary>
-        /// Encrypts the provided <paramref name="plaintextName"/> and materializes it.
-        /// </summary>
-        /// <param name="plaintextName">The name to encrypt.</param>
-        /// <param name="ciphertextParentFolder">The ciphertext parent folder.</param>
-        /// <param name="contentFolder">The content folder.</param>
-        /// <param name="security">The <see cref="Security"/> instance associated with the item.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that cancels this action.</param>
-        /// <returns>A <see cref="Task"/> that represents the asynchronous operation. Value is an encrypted name with the appropriate file extension appended.</returns>
-        public static async Task<string> EncryptNameForUseAsync(string plaintextName, IFolder ciphertextParentFolder, IFolder contentFolder,
-            Security security, CancellationToken cancellationToken = default)
-        {
-            if (security.NameCrypt is null)
-                return plaintextName;
-
-            var directoryId = AllocateDirectoryId(security, plaintextName);
-            var result = await GetDirectoryIdAsync(ciphertextParentFolder, contentFolder, directoryId, cancellationToken);
-
-            var encryptedName = security.NameCrypt.EncryptName(plaintextName, result ? directoryId : ReadOnlySpan<byte>.Empty) + Constants.Names.ENCRYPTED_FILE_EXTENSION;
-            if (SHORTENING_THRESHOLD > 0 && encryptedName.Length >= SHORTENING_THRESHOLD)
+            if (specifics.Options.ShorteningThreshold > 0 && encryptedName.Length >= specifics.Options.ShorteningThreshold)
             {
                 var shortenedBase = ComputeShortenedNameBase(encryptedName);
                 await WriteSidecarAsync(ciphertextParentFolder, shortenedBase, encryptedName, cancellationToken);

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Paths.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Paths.cs
@@ -20,7 +20,7 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
 
             foreach (var plaintextName in plaintextPath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries))
             {
-                var ciphertextName = await EncryptNameAsync(plaintextName, currentParent, specifics, cancellationToken);
+                var ciphertextName = await EncryptNameForDiscoveryAsync(plaintextName, currentParent, specifics, cancellationToken);
                 finalItem = await currentParent.GetFirstByNameAsync(ciphertextName, cancellationToken);
 
                 if (finalItem is IFolder nextParent)
@@ -56,12 +56,12 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
             foreach (var item in folderChain)
             {
                 // Walk through plaintext folder chain and retrieve ciphertext folders
-                var subCiphertextName = await EncryptNameAsync(item.Name, finalFolder, specifics, expendableDirectoryId, cancellationToken).ConfigureAwait(false);
+                var subCiphertextName = await EncryptNameForDiscoveryAsync(item.Name, finalFolder, specifics, expendableDirectoryId, cancellationToken).ConfigureAwait(false);
                 finalFolder = await finalFolder.GetFolderByNameAsync(subCiphertextName, cancellationToken);
             }
 
             // Encrypt and retrieve the final item
-            var ciphertextName = await EncryptNameAsync(plaintextStorable.Name, finalFolder, specifics, expendableDirectoryId, cancellationToken).ConfigureAwait(false);
+            var ciphertextName = await EncryptNameForDiscoveryAsync(plaintextStorable.Name, finalFolder, specifics, expendableDirectoryId, cancellationToken).ConfigureAwait(false);
             return await finalFolder.GetFirstByNameAsync(ciphertextName, cancellationToken);
         }
 

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Shortening.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Shortening.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Buffers.Text;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using OwlCore.Storage;
+using SecureFolderFS.Storage.Extensions;
+
+namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
+{
+    public static partial class AbstractPathHelpers
+    {
+        private const int SHORTENING_THRESHOLD = 220;
+        private const int MAX_SIDECAR_BYTES = 4096; // No legitimate ciphertext name approaches this upper bound
+
+        /// <summary>
+        /// Returns whether <paramref name="name"/> is a name-shortening sidecar file (<see cref="Constants.Names.SIDECAR_FILE_EXTENSION"/>).
+        /// Sidecar files are an internal implementation detail and should be excluded from vault enumeration.
+        /// </summary>
+        /// <returns>True, if the <paramref name="name"/> is a sidecar file; otherwise, false</returns>
+        public static bool IsSidecarName(string name)
+        {
+            return name.EndsWith(Constants.Names.SIDECAR_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Removes the shortened file extension from the specified filename if present.
+        /// </summary>
+        /// <returns>A <see cref="ReadOnlySpan{T}"/> or <see cref="char"/> without <see cref="Constants.Names.SHORTENED_FILE_EXTENSION"/>; otherwise, <paramref name="shortenedName"/>.</returns>
+        /// <remarks>
+        /// The returned <paramref name="shortenedName"/> may contain an extension other than <see cref="Constants.Names.SHORTENED_FILE_EXTENSION"/>.
+        /// </remarks>
+        public static ReadOnlySpan<char> RemoveShortenedExtension(string shortenedName)
+        {
+            return shortenedName.EndsWith(Constants.Names.SHORTENED_FILE_EXTENSION, StringComparison.Ordinal)
+                ? shortenedName.AsSpan(0, shortenedName.Length - Constants.Names.SHORTENED_FILE_EXTENSION.Length)
+                : shortenedName.AsSpan();
+        }
+
+        /// <summary>
+        /// Computes a deterministic, filesystem-safe name base (no extension) for a full ciphertext name.
+        /// The result is a URL-safe Base64 encoding of the first 20 bytes of SHA-256(UTF-8(<paramref name="ciphertextName"/>)),
+        /// yielding a fixed 27-character string.
+        /// </summary>
+        [SkipLocalsInit]
+        private static string ComputeShortenedNameBase(string ciphertextName)
+        {
+            var nameBytes = Encoding.UTF8.GetBytes(ciphertextName);
+            Span<byte> hash = stackalloc byte[32];
+            SHA256.HashData(nameBytes, hash);
+
+            return Base64Url.EncodeToString(hash.Slice(0, 20));
+        }
+
+        /// <summary>
+        /// Writes a sidecar file containing the full ciphertext name for a shortened file.
+        /// The sidecar is named <paramref name="shortenedBase"/> + <see cref="Constants.Names.SIDECAR_FILE_EXTENSION"/>.
+        /// Must be written before the shortened file/directory is created.
+        /// </summary>
+        private static async Task WriteSidecarAsync(
+            IFolder parentFolder,
+            string shortenedBase,
+            string fullCiphertextName,
+            CancellationToken cancellationToken)
+        {
+            if (parentFolder is not IModifiableFolder modifiableFolder)
+                throw new InvalidOperationException("Cannot write name-shortening sidecar: parent folder does not support modification.");
+
+            var sidecarName = shortenedBase + Constants.Names.SIDECAR_FILE_EXTENSION;
+            var sidecarFile = await modifiableFolder.CreateFileAsync(sidecarName, overwrite: true, cancellationToken);
+            await using var stream = await sidecarFile.OpenStreamAsync(FileAccess.Write, cancellationToken);
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(fullCiphertextName), cancellationToken);
+        }
+
+        /// <summary>
+        /// Reads the full ciphertext name from a sidecar file.
+        /// Returns <see langword="null"/> if the sidecar does not exist or cannot be read.
+        /// </summary>
+        private static async Task<string?> ReadSidecarAsync(
+            IFolder parentFolder,
+            string shortenedBase,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var sidecarName = shortenedBase + Constants.Names.SIDECAR_FILE_EXTENSION;
+                var sidecarFile = await parentFolder.TryGetFileByNameAsync(sidecarName, cancellationToken);
+                if (sidecarFile is null)
+                    return null;
+
+                await using var stream = await sidecarFile.OpenStreamAsync(FileAccess.Read, cancellationToken);
+                var buffer = new byte[MAX_SIDECAR_BYTES + 1];
+                var bytesRead = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken);
+                if (bytesRead > MAX_SIDECAR_BYTES)
+                    return null; // Reject malformed/malicious sidecar
+
+                return Encoding.UTF8.GetString(buffer.AsSpan(0, bytesRead));
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Shortening.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Shortening.cs
@@ -13,7 +13,7 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
 {
     public static partial class AbstractPathHelpers
     {
-        private const int MAX_SIDECAR_BYTES = 4096; // No legitimate ciphertext name approaches this upper bound
+        internal const int MAX_SIDECAR_BYTES = 4096; // No legitimate ciphertext name approaches this upper bound
 
         /// <summary>
         /// Tries to generate the name of the sidecar file associated with the given disk name.
@@ -79,7 +79,7 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
         /// <param name="ciphertextName">The full ciphertext name to compute the base for.</param>
         /// <returns>A deterministic, filesystem-safe name base (no extension) for <paramref name="ciphertextName"/>.</returns>
         [SkipLocalsInit]
-        private static string ComputeShortenedNameBase(string ciphertextName)
+        internal static string ComputeShortenedNameBase(string ciphertextName)
         {
             var nameBytes = Encoding.UTF8.GetBytes(ciphertextName);
             Span<byte> hash = stackalloc byte[32];

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Shortening.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Shortening.cs
@@ -32,21 +32,17 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
         /// </summary>
         /// <param name="ciphertextItemName">The shortened ciphertext name of the item.</param>
         /// <param name="ciphertextParent">The parent folder where the item is found.</param>
-        /// <param name="specifics">The <see cref="FileSystemSpecifics"/> instance associated with the item.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that cancels this action.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
-        public static async Task DeleteSidecarFileAsync(string ciphertextItemName, IModifiableFolder ciphertextParent, FileSystemSpecifics specifics, CancellationToken cancellationToken = default)
+        public static async Task DeleteSidecarFileAsync(string ciphertextItemName, IModifiableFolder ciphertextParent, CancellationToken cancellationToken = default)
         {
-            if (specifics.Options.ShorteningThreshold > 0 && ciphertextItemName.Length >= specifics.Options.ShorteningThreshold)
-            {
-                var oldSidecarName = TryGetSidecarName(ciphertextItemName);
-                if (oldSidecarName is null)
-                    return;
+            var oldSidecarName = TryGetSidecarName(ciphertextItemName);
+            if (oldSidecarName is null)
+                return;
 
-                var oldSidecar = await ciphertextParent.TryGetFileByNameAsync(oldSidecarName, cancellationToken);
-                if (oldSidecar is not null)
-                    await ciphertextParent.DeleteAsync(oldSidecar, cancellationToken);
-            }
+            var oldSidecar = await ciphertextParent.TryGetFileByNameAsync(oldSidecarName, cancellationToken);
+            if (oldSidecar is not null)
+                await ciphertextParent.DeleteAsync(oldSidecar, cancellationToken);
         }
 
         /// <summary>
@@ -70,7 +66,7 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
         /// </remarks>
         public static ReadOnlySpan<char> RemoveShortenedExtension(string shortenedName)
         {
-            return shortenedName.EndsWith(Constants.Names.SHORTENED_FILE_EXTENSION, StringComparison.Ordinal)
+            return shortenedName.EndsWith(Constants.Names.SHORTENED_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase)
                 ? shortenedName.AsSpan(0, shortenedName.Length - Constants.Names.SHORTENED_FILE_EXTENSION.Length)
                 : shortenedName.AsSpan();
         }

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Shortening.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Shortening.cs
@@ -13,7 +13,6 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
 {
     public static partial class AbstractPathHelpers
     {
-        private const int SHORTENING_THRESHOLD = 220;
         private const int MAX_SIDECAR_BYTES = 4096; // No legitimate ciphertext name approaches this upper bound
 
         /// <summary>

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Shortening.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Abstract/AbstractPathHelpers.Shortening.cs
@@ -16,9 +16,44 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
         private const int MAX_SIDECAR_BYTES = 4096; // No legitimate ciphertext name approaches this upper bound
 
         /// <summary>
+        /// Tries to generate the name of the sidecar file associated with the given disk name.
+        /// </summary>
+        /// <param name="diskName">The disk name to evaluate for a potential sidecar file name.</param>
+        /// <returns>A string representing the sidecar file name if the disk name matches the expected format, or null if it does not.</returns>
+        public static string? TryGetSidecarName(string diskName)
+        {
+            return diskName.EndsWith(Constants.Names.SHORTENED_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase)
+                ? RemoveShortenedExtension(diskName).ToString() + Constants.Names.SIDECAR_FILE_EXTENSION
+                : null;
+        }
+
+        /// <summary>
+        /// Deletes the sidecar file for a shortened item, if it exists.
+        /// </summary>
+        /// <param name="ciphertextItemName">The shortened ciphertext name of the item.</param>
+        /// <param name="ciphertextParent">The parent folder where the item is found.</param>
+        /// <param name="specifics">The <see cref="FileSystemSpecifics"/> instance associated with the item.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that cancels this action.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public static async Task DeleteSidecarFileAsync(string ciphertextItemName, IModifiableFolder ciphertextParent, FileSystemSpecifics specifics, CancellationToken cancellationToken = default)
+        {
+            if (specifics.Options.ShorteningThreshold > 0 && ciphertextItemName.Length >= specifics.Options.ShorteningThreshold)
+            {
+                var oldSidecarName = TryGetSidecarName(ciphertextItemName);
+                if (oldSidecarName is null)
+                    return;
+
+                var oldSidecar = await ciphertextParent.TryGetFileByNameAsync(oldSidecarName, cancellationToken);
+                if (oldSidecar is not null)
+                    await ciphertextParent.DeleteAsync(oldSidecar, cancellationToken);
+            }
+        }
+
+        /// <summary>
         /// Returns whether <paramref name="name"/> is a name-shortening sidecar file (<see cref="Constants.Names.SIDECAR_FILE_EXTENSION"/>).
         /// Sidecar files are an internal implementation detail and should be excluded from vault enumeration.
         /// </summary>
+        /// <param name="name">The name to evaluate.</param>
         /// <returns>True, if the <paramref name="name"/> is a sidecar file; otherwise, false</returns>
         public static bool IsSidecarName(string name)
         {
@@ -28,6 +63,7 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
         /// <summary>
         /// Removes the shortened file extension from the specified filename if present.
         /// </summary>
+        /// <param name="shortenedName">The filename with an optional shortened file extension.</param>
         /// <returns>A <see cref="ReadOnlySpan{T}"/> or <see cref="char"/> without <see cref="Constants.Names.SHORTENED_FILE_EXTENSION"/>; otherwise, <paramref name="shortenedName"/>.</returns>
         /// <remarks>
         /// The returned <paramref name="shortenedName"/> may contain an extension other than <see cref="Constants.Names.SHORTENED_FILE_EXTENSION"/>.
@@ -44,6 +80,8 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
         /// The result is a URL-safe Base64 encoding of the first 20 bytes of SHA-256(UTF-8(<paramref name="ciphertextName"/>)),
         /// yielding a fixed 27-character string.
         /// </summary>
+        /// <param name="ciphertextName">The full ciphertext name to compute the base for.</param>
+        /// <returns>A deterministic, filesystem-safe name base (no extension) for <paramref name="ciphertextName"/>.</returns>
         [SkipLocalsInit]
         private static string ComputeShortenedNameBase(string ciphertextName)
         {
@@ -59,10 +97,15 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
         /// The sidecar is named <paramref name="shortenedBase"/> + <see cref="Constants.Names.SIDECAR_FILE_EXTENSION"/>.
         /// Must be written before the shortened file/directory is created.
         /// </summary>
+        /// <param name="parentFolder">The parent folder where the sidecar file will be written.</param>
+        /// <param name="shortenedBase">The deterministic, filesystem-safe name base (no extension) for the shortened file.</param>
+        /// <param name="ciphertextName">The full ciphertext name to write to the sidecar file.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that cancels this action.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
         private static async Task WriteSidecarAsync(
             IFolder parentFolder,
             string shortenedBase,
-            string fullCiphertextName,
+            string ciphertextName,
             CancellationToken cancellationToken)
         {
             if (parentFolder is not IModifiableFolder modifiableFolder)
@@ -71,13 +114,17 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract
             var sidecarName = shortenedBase + Constants.Names.SIDECAR_FILE_EXTENSION;
             var sidecarFile = await modifiableFolder.CreateFileAsync(sidecarName, overwrite: true, cancellationToken);
             await using var stream = await sidecarFile.OpenStreamAsync(FileAccess.Write, cancellationToken);
-            await stream.WriteAsync(Encoding.UTF8.GetBytes(fullCiphertextName), cancellationToken);
+            await stream.WriteAsync(Encoding.UTF8.GetBytes(ciphertextName), cancellationToken);
         }
 
         /// <summary>
         /// Reads the full ciphertext name from a sidecar file.
         /// Returns <see langword="null"/> if the sidecar does not exist or cannot be read.
         /// </summary>
+        /// <param name="parentFolder">The parent folder where the sidecar file is located.</param>
+        /// <param name="shortenedBase">The deterministic, filesystem-safe name base (no extension) for the shortened file.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that cancels this action.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation. Value is the full ciphertext name contained in the sidecar file, or <see langword="null"/> if the sidecar does not exist or cannot be read.</returns>
         private static async Task<string?> ReadSidecarAsync(
             IFolder parentFolder,
             string shortenedBase,

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Native/NativePathHelpers.Directory.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Native/NativePathHelpers.Directory.cs
@@ -5,6 +5,13 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Native
 {
     public static partial class NativePathHelpers
     {
+        /// <summary>
+        /// Gets the Directory ID for the specified ciphertext folder.
+        /// </summary>
+        /// <param name="ciphertextFolderPath">The ciphertext folder path on disk.</param>
+        /// <param name="specifics">The <see cref="FileSystemSpecifics"/> instance associated with the item.</param>
+        /// <param name="directoryId">A <see cref="Span{T}"/> of size <see cref="Constants.DIRECTORY_ID_SIZE"/> which will be filled with the Directory ID data.</param>
+        /// <returns>True if a Directory ID was read; false if the folder is the root.</returns>
         public static bool GetDirectoryId(string ciphertextFolderPath, FileSystemSpecifics specifics, Span<byte> directoryId)
         {
             // Check if we're at the root

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Native/NativePathHelpers.Names.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Native/NativePathHelpers.Names.cs
@@ -5,46 +5,184 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Native
 {
     public static partial class NativePathHelpers
     {
-        public static string EncryptName(string plaintextName, string plaintextParentFolder,
+        #region Encrypt Name Non-Materialized
+
+        /// <inheritdoc cref="EncryptName(string,string,FileSystemSpecifics,Span{byte})"/>
+        public static string EncryptName(string plaintextName, string ciphertextParentFolder,
             FileSystemSpecifics specifics)
         {
             if (specifics.Security.NameCrypt is null)
                 return plaintextName;
 
             var directoryId = AbstractPathHelpers.AllocateDirectoryId(specifics.Security, plaintextName);
-            return EncryptName(plaintextName, plaintextParentFolder, specifics, directoryId);
+            return EncryptName(plaintextName, ciphertextParentFolder, specifics, directoryId);
         }
 
-        public static string EncryptName(string plaintextName, string plaintextParentFolder,
+        /// <summary>
+        /// Encrypts the provided <paramref name="plaintextName"/>.
+        /// </summary>
+        /// <param name="plaintextName">The name to encrypt.</param>
+        /// <param name="ciphertextParentFolder">The ciphertext parent folder path.</param>
+        /// <param name="specifics">The <see cref="FileSystemSpecifics"/> instance associated with the item.</param>
+        /// <param name="expendableDirectoryId">A <see cref="Span{T}"/> of size <see cref="Constants.DIRECTORY_ID_SIZE"/> which will be used to hold the Directory ID data.</param>
+        /// <returns>An encrypted name with the appropriate file extension appended.</returns>
+        public static string EncryptName(string plaintextName, string ciphertextParentFolder,
             FileSystemSpecifics specifics, Span<byte> expendableDirectoryId)
         {
             if (specifics.Security.NameCrypt is null)
                 return plaintextName;
 
-            var result = GetDirectoryId(plaintextParentFolder, specifics, expendableDirectoryId);
+            var result = GetDirectoryId(ciphertextParentFolder, specifics, expendableDirectoryId);
             return specifics.Security.NameCrypt.EncryptName(plaintextName, result ? expendableDirectoryId : ReadOnlySpan<byte>.Empty) + Constants.Names.ENCRYPTED_FILE_EXTENSION;
         }
 
+        #endregion
+
+        #region Encrypt Name Materialized
+
+        /// <inheritdoc cref="EncryptNameForUse(string,string,FileSystemSpecifics,Span{byte})"/>
+        public static string EncryptNameForUse(string plaintextName, string ciphertextParentFolder,
+            FileSystemSpecifics specifics)
+        {
+            if (specifics.Security.NameCrypt is null)
+                return plaintextName;
+
+            var directoryId = AbstractPathHelpers.AllocateDirectoryId(specifics.Security, plaintextName);
+            return EncryptNameForUse(plaintextName, ciphertextParentFolder, specifics, directoryId);
+        }
+
+        /// <summary>
+        /// Encrypts the provided <paramref name="plaintextName"/> and materializes it.
+        /// If the encrypted name exceeds the shortening threshold, a sidecar file is written and the shortened name is returned.
+        /// </summary>
+        /// <param name="plaintextName">The name to encrypt.</param>
+        /// <param name="ciphertextParentFolder">The ciphertext parent folder path.</param>
+        /// <param name="specifics">The <see cref="FileSystemSpecifics"/> instance associated with the item.</param>
+        /// <param name="expendableDirectoryId">A <see cref="Span{T}"/> of size <see cref="Constants.DIRECTORY_ID_SIZE"/> which will be used to hold the Directory ID data.</param>
+        /// <returns>An encrypted name with the appropriate file extension appended.</returns>
+        public static string EncryptNameForUse(string plaintextName, string ciphertextParentFolder,
+            FileSystemSpecifics specifics, Span<byte> expendableDirectoryId)
+        {
+            if (specifics.Security.NameCrypt is null)
+                return plaintextName;
+
+            var result = GetDirectoryId(ciphertextParentFolder, specifics, expendableDirectoryId);
+            var encryptedName = specifics.Security.NameCrypt.EncryptName(plaintextName, result ? expendableDirectoryId : ReadOnlySpan<byte>.Empty) + Constants.Names.ENCRYPTED_FILE_EXTENSION;
+
+            if (specifics.Options.ShorteningThreshold > 0 && encryptedName.Length >= specifics.Options.ShorteningThreshold)
+            {
+                var shortenedBase = AbstractPathHelpers.ComputeShortenedNameBase(encryptedName);
+                WriteSidecar(ciphertextParentFolder, shortenedBase, encryptedName);
+                return shortenedBase + Constants.Names.SHORTENED_FILE_EXTENSION;
+            }
+
+            return encryptedName;
+        }
+
+        #endregion
+
+        #region Encrypt Name Discoverability
+
+        /// <inheritdoc cref="EncryptNameForDiscovery(string,string,FileSystemSpecifics,Span{byte})"/>
+        public static string EncryptNameForDiscovery(string plaintextName, string ciphertextParentFolder,
+            FileSystemSpecifics specifics)
+        {
+            if (specifics.Security.NameCrypt is null)
+                return plaintextName;
+
+            var directoryId = AbstractPathHelpers.AllocateDirectoryId(specifics.Security, plaintextName);
+            return EncryptNameForDiscovery(plaintextName, ciphertextParentFolder, specifics, directoryId);
+        }
+
+        /// <summary>
+        /// Encrypts the provided <paramref name="plaintextName"/> and discovers potential shortening branch.
+        /// Unlike <see cref="EncryptNameForUse(string,string,FileSystemSpecifics,Span{byte})"/>, this method does not write a sidecar file.
+        /// </summary>
+        /// <param name="plaintextName">The name to encrypt.</param>
+        /// <param name="ciphertextParentFolder">The ciphertext parent folder path.</param>
+        /// <param name="specifics">The <see cref="FileSystemSpecifics"/> instance associated with the item.</param>
+        /// <param name="expendableDirectoryId">A <see cref="Span{T}"/> of size <see cref="Constants.DIRECTORY_ID_SIZE"/> which will be used to hold the Directory ID data.</param>
+        /// <returns>An encrypted name with the appropriate file extension appended.</returns>
+        public static string EncryptNameForDiscovery(string plaintextName, string ciphertextParentFolder,
+            FileSystemSpecifics specifics, Span<byte> expendableDirectoryId)
+        {
+            if (specifics.Security.NameCrypt is null)
+                return plaintextName;
+
+            var result = GetDirectoryId(ciphertextParentFolder, specifics, expendableDirectoryId);
+            var encryptedName = specifics.Security.NameCrypt.EncryptName(plaintextName, result ? expendableDirectoryId : ReadOnlySpan<byte>.Empty) + Constants.Names.ENCRYPTED_FILE_EXTENSION;
+
+            if (specifics.Options.ShorteningThreshold > 0 && encryptedName.Length >= specifics.Options.ShorteningThreshold)
+            {
+                var shortenedBase = AbstractPathHelpers.ComputeShortenedNameBase(encryptedName);
+                return shortenedBase + Constants.Names.SHORTENED_FILE_EXTENSION;
+            }
+
+            return encryptedName;
+        }
+
+        #endregion
+
+        #region Decrypt Name
+
+        /// <inheritdoc cref="DecryptName(string,string,FileSystemSpecifics,Span{byte})"/>
         public static string? DecryptName(string ciphertextName, string ciphertextParentFolder,
             FileSystemSpecifics specifics)
         {
             if (specifics.Security.NameCrypt is null)
                 return ciphertextName;
 
+            // Sidecar files are internal bookkeeping - they have no plaintext name
+            if (AbstractPathHelpers.IsSidecarName(ciphertextName))
+                return null;
+
             var directoryId = AbstractPathHelpers.AllocateDirectoryId(specifics.Security, ciphertextName);
             return DecryptName(ciphertextName, ciphertextParentFolder, specifics, directoryId);
         }
 
+        /// <summary>
+        /// Decrypts the provided <paramref name="ciphertextName"/>.
+        /// Resolves shortened names (<c>.sffsn</c>) to their full ciphertext name via the paired sidecar before decrypting.
+        /// </summary>
+        /// <param name="ciphertextName">The name to decrypt.</param>
+        /// <param name="ciphertextParentFolder">The ciphertext parent folder path.</param>
+        /// <param name="specifics">The <see cref="FileSystemSpecifics"/> instance associated with the item.</param>
+        /// <param name="expendableDirectoryId">A <see cref="Span{T}"/> of size <see cref="Constants.DIRECTORY_ID_SIZE"/> which will be used to hold the Directory ID data.</param>
+        /// <returns>A decrypted name, or <see langword="null"/> if decryption fails.</returns>
         public static string? DecryptName(string ciphertextName, string ciphertextParentFolder,
             FileSystemSpecifics specifics, Span<byte> expendableDirectoryId)
         {
             if (specifics.Security.NameCrypt is null)
                 return ciphertextName;
 
-            var result = GetDirectoryId(ciphertextParentFolder, specifics, expendableDirectoryId);
-            var normalizedName = AbstractPathHelpers.RemoveCiphertextExtension(ciphertextName);
+            // Sidecar files are internal bookkeeping - they have no plaintext name
+            if (AbstractPathHelpers.IsSidecarName(ciphertextName))
+                return null;
 
-            return specifics.Security.NameCrypt.DecryptName(normalizedName, result ? expendableDirectoryId : ReadOnlySpan<byte>.Empty);
+            try
+            {
+                // Resolve shortened names to their full ciphertext name via the paired sidecar
+                if (ciphertextName.EndsWith(Constants.Names.SHORTENED_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase))
+                {
+                    var shortenedBase = AbstractPathHelpers.RemoveShortenedExtension(ciphertextName).ToString();
+                    var resolvedName = ReadSidecar(ciphertextParentFolder, shortenedBase);
+                    if (resolvedName is null)
+                        return null;
+
+                    ciphertextName = resolvedName;
+                }
+
+                var result = GetDirectoryId(ciphertextParentFolder, specifics, expendableDirectoryId);
+                var normalizedName = AbstractPathHelpers.RemoveCiphertextExtension(ciphertextName);
+
+                return specifics.Security.NameCrypt.DecryptName(normalizedName, result ? expendableDirectoryId : ReadOnlySpan<byte>.Empty);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
         }
+
+        #endregion
     }
 }

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Native/NativePathHelpers.Paths.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Native/NativePathHelpers.Paths.cs
@@ -18,6 +18,54 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Native
         }
 
         /// <summary>
+        /// Encrypts and gets the ciphertext path from provided <paramref name="plaintextRelativePath"/>,
+        /// writing sidecar files for any name that exceeds the shortening threshold.
+        /// </summary>
+        /// <param name="plaintextRelativePath">The relative plaintext path to an item.</param>
+        /// <param name="specifics">The specifics.</param>
+        /// <returns>A full ciphertext path.</returns>
+        public static string GetCiphertextPathForUse(string plaintextRelativePath, FileSystemSpecifics specifics)
+        {
+            var directoryId = new byte[Constants.DIRECTORY_ID_SIZE];
+            return GetCiphertextPathForUse(plaintextRelativePath, specifics, directoryId);
+        }
+
+        /// <summary>
+        /// Encrypts and gets the ciphertext path from provided <paramref name="plaintextRelativePath"/>,
+        /// writing sidecar files for any name that exceeds the shortening threshold.
+        /// </summary>
+        /// <param name="plaintextRelativePath">The relative plaintext path to an item.</param>
+        /// <param name="specifics">The specifics.</param>
+        /// <param name="expendableDirectoryId">A <see cref="Span{T}"/> of size <see cref="Constants.DIRECTORY_ID_SIZE"/> which will be used to hold the Directory ID data.</param>
+        /// <returns>A full ciphertext path.</returns>
+        public static string GetCiphertextPathForUse(string plaintextRelativePath, FileSystemSpecifics specifics, Span<byte> expendableDirectoryId)
+        {
+            // Make path relative as a precaution (if the path is passed as ContentPath + PlaintextPath)
+            plaintextRelativePath = MakeRelative(plaintextRelativePath, specifics.ContentFolder.Id);
+
+            // Return the (full) path, if not using name encryption
+            if (specifics.Security.NameCrypt is null)
+            {
+                if (plaintextRelativePath.StartsWith(Path.DirectorySeparatorChar))
+                    return specifics.ContentFolder.Id + plaintextRelativePath;
+
+                return Path.Combine(specifics.ContentFolder.Id, plaintextRelativePath);
+            }
+
+            var finalPath = specifics.ContentFolder.Id;
+            foreach (var namePart in plaintextRelativePath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries))
+            {
+                // Encrypt the name part and materialize sidecar if shortened
+                var ciphertextName = EncryptNameForUse(namePart, finalPath, specifics, expendableDirectoryId);
+
+                // Combine the final path
+                finalPath = Path.Combine(finalPath, ciphertextName);
+            }
+
+            return finalPath;
+        }
+
+        /// <summary>
         /// Decrypts and gets the plaintext path from provided <paramref name="ciphertextPath"/>.
         /// </summary>
         /// <param name="ciphertextPath">The relative plaintext path to an item.</param>
@@ -58,8 +106,8 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Native
             var finalPath = specifics.ContentFolder.Id;
             foreach (var namePart in plaintextRelativePath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries))
             {
-                // Encrypt the name part
-                var ciphertextName = EncryptName(namePart, finalPath, specifics, expendableDirectoryId);
+                // Encrypt the name part (discovery only — no sidecar write)
+                var ciphertextName = EncryptNameForDiscovery(namePart, finalPath, specifics, expendableDirectoryId);
 
                 // Combine the final path
                 finalPath = Path.Combine(finalPath, ciphertextName);

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Native/NativePathHelpers.Shortening.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Native/NativePathHelpers.Shortening.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+using System.Text;
+using SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract;
+
+namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Native
+{
+    public static partial class NativePathHelpers
+    {
+        /// <summary>
+        /// Writes a sidecar file containing the full ciphertext name for a shortened file.
+        /// </summary>
+        /// <param name="ciphertextParentPath">The ciphertext parent folder path on disk.</param>
+        /// <param name="shortenedBase">The deterministic shortened name base (no extension).</param>
+        /// <param name="ciphertextName">The full ciphertext name to store in the sidecar.</param>
+        private static void WriteSidecar(string ciphertextParentPath, string shortenedBase, string ciphertextName)
+        {
+            var sidecarPath = Path.Combine(ciphertextParentPath, shortenedBase + Constants.Names.SIDECAR_FILE_EXTENSION);
+            File.WriteAllText(sidecarPath, ciphertextName, Encoding.UTF8);
+        }
+
+        /// <summary>
+        /// Reads the full ciphertext name from a sidecar file.
+        /// Returns <see langword="null"/> if the sidecar does not exist or cannot be read.
+        /// </summary>
+        /// <param name="ciphertextParentPath">The ciphertext parent folder path on disk.</param>
+        /// <param name="shortenedBase">The deterministic shortened name base (no extension).</param>
+        /// <returns>The full ciphertext name, or <see langword="null"/> if the sidecar cannot be read.</returns>
+        private static string? ReadSidecar(string ciphertextParentPath, string shortenedBase)
+        {
+            try
+            {
+                var sidecarPath = Path.Combine(ciphertextParentPath, shortenedBase + Constants.Names.SIDECAR_FILE_EXTENSION);
+                if (!File.Exists(sidecarPath))
+                    return null;
+
+                var content = File.ReadAllText(sidecarPath, Encoding.UTF8);
+                if (content.Length > AbstractPathHelpers.MAX_SIDECAR_BYTES)
+                    return null; // Reject malformed/malicious sidecar
+
+                return content;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Deletes the sidecar file for a shortened item, if it exists.
+        /// </summary>
+        /// <param name="ciphertextItemName">The shortened ciphertext name of the item.</param>
+        /// <param name="ciphertextParentPath">The ciphertext parent folder path on disk.</param>
+        public static void DeleteSidecarFile(string ciphertextItemName, string ciphertextParentPath)
+        {
+            var sidecarName = AbstractPathHelpers.TryGetSidecarName(ciphertextItemName);
+            if (sidecarName is null)
+                return;
+
+            var sidecarPath = Path.Combine(ciphertextParentPath, sidecarName);
+            if (File.Exists(sidecarPath))
+                File.Delete(sidecarPath);
+        }
+    }
+}

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Native/NativePathHelpers.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/Native/NativePathHelpers.cs
@@ -7,6 +7,12 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths.Native
     /// </summary>
     public static partial class NativePathHelpers
     {
+        /// <summary>
+        /// Makes the provided <paramref name="fullPath"/> relative to the specified <paramref name="basePath"/>.
+        /// </summary>
+        /// <param name="fullPath">The full path to convert.</param>
+        /// <param name="basePath">The base path to make the full path relative to.</param>
+        /// <returns>A relative path with a leading directory separator.</returns>
         public static string MakeRelative(string fullPath, string basePath)
         {
             return PathHelpers.EnsureNoLeadingPathSeparator(Path.DirectorySeparatorChar + fullPath.Replace(basePath, string.Empty));

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/PathHelpers.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/Paths/PathHelpers.cs
@@ -11,6 +11,7 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.Paths
         public static bool IsCoreName(string itemName)
         {
             return
+                itemName.EndsWith(Constants.Names.SIDECAR_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase) ||
                 itemName.Contains(Constants.Names.DIRECTORY_ID_FILENAME, StringComparison.OrdinalIgnoreCase) ||
                 itemName.Contains(Constants.Names.RECYCLE_BIN_NAME, StringComparison.OrdinalIgnoreCase) ||
                 itemName.Contains(Constants.Names.RECYCLE_BIN_CONFIGURATION_FILENAME, StringComparison.OrdinalIgnoreCase);

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/RecycleBin/Abstract/AbstractRecycleBinHelpers.Operational.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/RecycleBin/Abstract/AbstractRecycleBinHelpers.Operational.cs
@@ -7,7 +7,6 @@ using SecureFolderFS.Core.FileSystem.DataModels;
 using SecureFolderFS.Core.FileSystem.Helpers.Paths.Abstract;
 using SecureFolderFS.Shared.ComponentModel;
 using SecureFolderFS.Shared.Extensions;
-using SecureFolderFS.Shared.Helpers;
 using SecureFolderFS.Storage.Extensions;
 using SecureFolderFS.Storage.VirtualFileSystem;
 
@@ -73,31 +72,17 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.RecycleBin.Abstract
             if (plaintextOriginalName is null || plaintextParentPath is null)
                 throw new FormatException("Could not decrypt recycle bin configuration file.");
 
-            var ciphertextParentFolder = await SafetyHelpers.NoFailureAsync(async () => await AbstractPathHelpers.GetCiphertextItemAsync(plaintextParentPath, specifics, cancellationToken) as IFolder);
-            if (string.IsNullOrEmpty(ciphertextParentFolder?.Id) || !ciphertextDestinationFolder.Id.EndsWith(ciphertextParentFolder.Id))
-            {
-                // Destination folder is different from the original destination
-                // A new item name should be chosen fit for the new folder (so that Directory ID match)
-                var ciphertextName = await AbstractPathHelpers.EncryptNameForDiscoveryAsync(plaintextOriginalName, ciphertextDestinationFolder, specifics, cancellationToken);
+            // Encrypt the name for discovery (no sidecar side-effects)
+            var ciphertextName = await AbstractPathHelpers.EncryptNameForDiscoveryAsync(plaintextOriginalName, ciphertextDestinationFolder, specifics, cancellationToken);
 
-                // Get an available name if the destination already exists
-                ciphertextName = await GetAvailableDestinationNameAsync(ciphertextDestinationFolder, ciphertextName, plaintextOriginalName, specifics, cancellationToken);
+            // Get an available name if the destination already has an item with that name
+            var (_, finalPlaintextName) = await GetAvailableDestinationNameAsync(ciphertextDestinationFolder, ciphertextName, plaintextOriginalName, specifics, cancellationToken);
 
-                // Rename and move item to destination
-                _ = await ciphertextDestinationFolder.MoveStorableFromAsync(recycleBinItem, modifiableRecycleBin, false, ciphertextName, null, cancellationToken);
-            }
-            else
-            {
-                // Destination folder is the same as the original destination
-                // The same name could be used since the Directory IDs match
-                var ciphertextName = await AbstractPathHelpers.EncryptNameForDiscoveryAsync(plaintextOriginalName, ciphertextDestinationFolder, specifics, cancellationToken);
+            // Materialize the name: writes the sidecar file if the name is shortened
+            ciphertextName = await AbstractPathHelpers.EncryptNameForUseAsync(finalPlaintextName, ciphertextDestinationFolder, specifics, cancellationToken);
 
-                // Get an available name if the destination already exists
-                ciphertextName = await GetAvailableDestinationNameAsync(ciphertextDestinationFolder, ciphertextName, plaintextOriginalName, specifics, cancellationToken);
-
-                // Rename and move item to destination
-                _ = await ciphertextDestinationFolder.MoveStorableFromAsync(recycleBinItem, modifiableRecycleBin, false, ciphertextName, null, cancellationToken);
-            }
+            // Rename and move item to destination
+            _ = await ciphertextDestinationFolder.MoveStorableFromAsync(recycleBinItem, modifiableRecycleBin, false, ciphertextName, null, cancellationToken);
 
             // Delete the old configuration file
             var configurationFile = await recycleBin.GetFileByNameAsync($"{recycleBinItem.Name}.json", cancellationToken);
@@ -231,8 +216,10 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.RecycleBin.Abstract
             }
         }
 
-        private static async Task<string> GetAvailableDestinationNameAsync(IFolder ciphertextDestinationFolder, string ciphertextName, string plaintextOriginalName, FileSystemSpecifics specifics, CancellationToken cancellationToken)
+        private static async Task<(string CiphertextName, string PlaintextName)> GetAvailableDestinationNameAsync(IFolder ciphertextDestinationFolder, string ciphertextName, string plaintextOriginalName, FileSystemSpecifics specifics, CancellationToken cancellationToken)
         {
+            var finalPlaintextName = plaintextOriginalName;
+
             // Check if the item already exists
             var existing = await ciphertextDestinationFolder.TryGetFirstByNameAsync(ciphertextName, cancellationToken);
             if (existing is not null)
@@ -243,14 +230,14 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.RecycleBin.Abstract
                 var suffix = 1;
                 do
                 {
-                    var newPlaintextName = $"{nameWithoutExtension} ({suffix}){extension}";
-                    ciphertextName = await AbstractPathHelpers.EncryptNameForDiscoveryAsync(newPlaintextName, ciphertextDestinationFolder, specifics, cancellationToken);
+                    finalPlaintextName = $"{nameWithoutExtension} ({suffix}){extension}";
+                    ciphertextName = await AbstractPathHelpers.EncryptNameForDiscoveryAsync(finalPlaintextName, ciphertextDestinationFolder, specifics, cancellationToken);
                     existing = await ciphertextDestinationFolder.TryGetFirstByNameAsync(ciphertextName, cancellationToken);
                     suffix++;
                 } while (existing is not null);
             }
 
-            return ciphertextName;
+            return (ciphertextName, finalPlaintextName);
         }
 
         private static async Task<bool> IsRecentlyCreatedAsync(IStorable storable, CancellationToken cancellationToken)

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/RecycleBin/Abstract/AbstractRecycleBinHelpers.Operational.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/RecycleBin/Abstract/AbstractRecycleBinHelpers.Operational.cs
@@ -78,7 +78,7 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.RecycleBin.Abstract
             {
                 // Destination folder is different from the original destination
                 // A new item name should be chosen fit for the new folder (so that Directory ID match)
-                var ciphertextName = await AbstractPathHelpers.EncryptNameAsync(plaintextOriginalName, ciphertextDestinationFolder, specifics, cancellationToken);
+                var ciphertextName = await AbstractPathHelpers.EncryptNameForDiscoveryAsync(plaintextOriginalName, ciphertextDestinationFolder, specifics, cancellationToken);
 
                 // Get an available name if the destination already exists
                 ciphertextName = await GetAvailableDestinationNameAsync(ciphertextDestinationFolder, ciphertextName, plaintextOriginalName, specifics, cancellationToken);
@@ -90,7 +90,7 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.RecycleBin.Abstract
             {
                 // Destination folder is the same as the original destination
                 // The same name could be used since the Directory IDs match
-                var ciphertextName = await AbstractPathHelpers.EncryptNameAsync(plaintextOriginalName, ciphertextDestinationFolder, specifics, cancellationToken);
+                var ciphertextName = await AbstractPathHelpers.EncryptNameForDiscoveryAsync(plaintextOriginalName, ciphertextDestinationFolder, specifics, cancellationToken);
 
                 // Get an available name if the destination already exists
                 ciphertextName = await GetAvailableDestinationNameAsync(ciphertextDestinationFolder, ciphertextName, plaintextOriginalName, specifics, cancellationToken);
@@ -244,7 +244,7 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.RecycleBin.Abstract
                 do
                 {
                     var newPlaintextName = $"{nameWithoutExtension} ({suffix}){extension}";
-                    ciphertextName = await AbstractPathHelpers.EncryptNameAsync(newPlaintextName, ciphertextDestinationFolder, specifics, cancellationToken);
+                    ciphertextName = await AbstractPathHelpers.EncryptNameForDiscoveryAsync(newPlaintextName, ciphertextDestinationFolder, specifics, cancellationToken);
                     existing = await ciphertextDestinationFolder.TryGetFirstByNameAsync(ciphertextName, cancellationToken);
                     suffix++;
                 } while (existing is not null);

--- a/src/Core/SecureFolderFS.Core.FileSystem/Helpers/RecycleBin/Native/NativeRecycleBinHelpers.Operational.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Helpers/RecycleBin/Native/NativeRecycleBinHelpers.Operational.cs
@@ -19,6 +19,11 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.RecycleBin.Native
                 throw FileSystemExceptions.FileSystemReadOnly;
 
             storableType = AlignStorableType(ciphertextPath);
+
+            // Compute parent path early so it's available in all branches
+            var ciphertextParentPath = Path.GetDirectoryName(ciphertextPath);
+            _ = ciphertextParentPath ?? throw new DirectoryNotFoundException("The parent folder could not be determined.");
+
             if (!specifics.Options.IsRecycleBinEnabled())
             {
                 DeleteImmediately(ciphertextPath, storableType);
@@ -28,9 +33,7 @@ namespace SecureFolderFS.Core.FileSystem.Helpers.RecycleBin.Native
             // Allocate Directory ID for later use
             var directoryId = AbstractPathHelpers.AllocateDirectoryId(specifics.Security);
 
-            // Decrypt the plaintext name
-            var ciphertextParentPath = Path.GetDirectoryName(ciphertextPath);
-            _ = ciphertextParentPath ?? throw new DirectoryNotFoundException("The parent folder could not be determined.");
+            // Decrypt the plaintext name (reads sidecar if shortened)
             var plaintextName = NativePathHelpers.DecryptName(Path.GetFileName(ciphertextPath), ciphertextParentPath, specifics, directoryId);
             if (plaintextName is null)
                 throw new FormatException("Could not decrypt name for recycle bin configuration file.");

--- a/src/Core/SecureFolderFS.Core.FileSystem/Storage/CryptoFolder.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Storage/CryptoFolder.cs
@@ -15,6 +15,7 @@ using SecureFolderFS.Shared.Models;
 using SecureFolderFS.Storage.Extensions;
 using SecureFolderFS.Storage.Recyclable;
 using SecureFolderFS.Storage.Renamable;
+using SecureFolderFS.Storage.VirtualFileSystem;
 
 namespace SecureFolderFS.Core.FileSystem.Storage
 {
@@ -43,6 +44,9 @@ namespace SecureFolderFS.Core.FileSystem.Storage
         /// <inheritdoc/>
         public virtual async Task<IStorableChild> RenameAsync(IStorableChild storable, string newName, CancellationToken cancellationToken = default)
         {
+            if (specifics.Options.IsReadOnly)
+                throw FileSystemExceptions.FileSystemReadOnly;
+
             if (Inner is not IRenamableFolder renamableFolder)
                 throw new NotSupportedException("Renaming folder contents is not supported.");
 
@@ -112,6 +116,9 @@ namespace SecureFolderFS.Core.FileSystem.Storage
         /// <inheritdoc/>
         public virtual async Task DeleteAsync(IStorableChild item, long sizeHint = -1L, bool deleteImmediately = false, CancellationToken cancellationToken = default)
         {
+            if (specifics.Options.IsReadOnly)
+                throw FileSystemExceptions.FileSystemReadOnly;
+
             if (Inner is not IModifiableFolder modifiableFolder)
                 throw new NotSupportedException("Modifying folder contents is not supported.");
 
@@ -138,10 +145,13 @@ namespace SecureFolderFS.Core.FileSystem.Storage
         /// <inheritdoc/>
         public virtual async Task<IChildFolder> CreateFolderAsync(string name, bool overwrite = false, CancellationToken cancellationToken = default)
         {
+            if (specifics.Options.IsReadOnly)
+                throw FileSystemExceptions.FileSystemReadOnly;
+
             if (Inner is not IModifiableFolder modifiableFolder)
                 throw new NotSupportedException("Modifying folder contents is not supported.");
 
-            var encryptedName = await AbstractPathHelpers.EncryptNameAsync(name, Inner, specifics, cancellationToken);
+            var encryptedName = await AbstractPathHelpers.EncryptNameForUseAsync(name, Inner, specifics, cancellationToken);
             var folder = await modifiableFolder.CreateFolderAsync(encryptedName, overwrite, cancellationToken);
             if (folder is not IModifiableFolder createdModifiableFolder)
                 throw new ArgumentException("The created folder is not modifiable.");
@@ -163,10 +173,13 @@ namespace SecureFolderFS.Core.FileSystem.Storage
         /// <inheritdoc/>
         public virtual async Task<IChildFile> CreateFileAsync(string name, bool overwrite = false, CancellationToken cancellationToken = default)
         {
+            if (specifics.Options.IsReadOnly)
+                throw FileSystemExceptions.FileSystemReadOnly;
+
             if (Inner is not IModifiableFolder modifiableFolder)
                 throw new NotSupportedException("Modifying folder contents is not supported.");
 
-            var encryptedName = await AbstractPathHelpers.EncryptNameAsync(name, Inner, specifics, cancellationToken);
+            var encryptedName = await AbstractPathHelpers.EncryptNameForUseAsync(name, Inner, specifics, cancellationToken);
             var file = await modifiableFolder.CreateFileAsync(encryptedName, overwrite, cancellationToken);
 
             return (IChildFile)Wrap(file, name);
@@ -183,6 +196,9 @@ namespace SecureFolderFS.Core.FileSystem.Storage
         public virtual async Task<IChildFile> CreateCopyOfAsync(IFile fileToCopy, bool overwrite, string newName, CancellationToken cancellationToken,
             CreateRenamedCopyOfDelegate fallback)
         {
+            if (specifics.Options.IsReadOnly)
+                throw FileSystemExceptions.FileSystemReadOnly;
+
             if (Inner is not IModifiableFolder)
                 throw new NotSupportedException("Modifying folder contents is not supported.");
 
@@ -195,7 +211,7 @@ namespace SecureFolderFS.Core.FileSystem.Storage
                 return await fallback(this, fileToCopy, overwrite, newName, cancellationToken);
 
             // Encrypt the new name
-            var ciphertextNewName = await AbstractPathHelpers.EncryptNameAsync(newName, Inner, specifics, cancellationToken);
+            var ciphertextNewName = await AbstractPathHelpers.EncryptNameForUseAsync(newName, Inner, specifics, cancellationToken);
 
             // Copy the ciphertext file
             var copiedCiphertextFile = await createRenamedCopyOf.CreateCopyOfAsync(ciphertextFileToCopy, overwrite, ciphertextNewName, cancellationToken);
@@ -213,6 +229,9 @@ namespace SecureFolderFS.Core.FileSystem.Storage
         public virtual async Task<IChildFile> MoveFromAsync(IChildFile fileToMove, IModifiableFolder source, bool overwrite, string newName,
             CancellationToken cancellationToken, MoveRenamedFromDelegate fallback)
         {
+            if (specifics.Options.IsReadOnly)
+                throw FileSystemExceptions.FileSystemReadOnly;
+
             if (Inner is not IModifiableFolder)
                 throw new NotSupportedException("Modifying folder contents is not supported.");
 
@@ -231,7 +250,7 @@ namespace SecureFolderFS.Core.FileSystem.Storage
                 return await fallback(this, fileToMove, source, overwrite, newName, cancellationToken);
 
             // Encrypt the new name
-            var newCiphertextName = await AbstractPathHelpers.EncryptNameAsync(newName, Inner, specifics, cancellationToken);
+            var newCiphertextName = await AbstractPathHelpers.EncryptNameForUseAsync(newName, Inner, specifics, cancellationToken);
 
             // Move the ciphertext file
             var movedCiphertextFile = await moveRenamedFrom.MoveFromAsync(ciphertextFileToMove, ciphertextSourceModifiableFolder, overwrite, newCiphertextName, cancellationToken, fallback);

--- a/src/Core/SecureFolderFS.Core.FileSystem/Storage/CryptoFolder.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Storage/CryptoFolder.cs
@@ -59,7 +59,7 @@ namespace SecureFolderFS.Core.FileSystem.Storage
             var renamedCiphertextItem = await renamableFolder.RenameAsync(ciphertextItem, newCiphertextName, cancellationToken);
 
             // Clean up old sidecar if the old name was shortened
-            await AbstractPathHelpers.DeleteSidecarFileAsync(ciphertextName, renamableFolder, specifics, cancellationToken);
+            await AbstractPathHelpers.DeleteSidecarFileAsync(ciphertextName, renamableFolder, cancellationToken);
 
             var plaintextId = Path.Combine(Inner.Id, newName);
             return renamedCiphertextItem switch
@@ -141,7 +141,7 @@ namespace SecureFolderFS.Core.FileSystem.Storage
             }
 
             // Clean up old sidecar if the old name was shortened
-            await AbstractPathHelpers.DeleteSidecarFileAsync(ciphertextName, modifiableFolder, specifics, cancellationToken);
+            await AbstractPathHelpers.DeleteSidecarFileAsync(ciphertextName, modifiableFolder, cancellationToken);
 
             // Remove deleted directory from cache
             if (ciphertextItem is IFolder)
@@ -262,7 +262,7 @@ namespace SecureFolderFS.Core.FileSystem.Storage
             var movedCiphertextFile = await moveRenamedFrom.MoveFromAsync(ciphertextFileToMove, ciphertextSourceModifiableFolder, overwrite, newCiphertextName, cancellationToken, fallback);
 
             // Clean up old sidecar if the old name was shortened
-            await AbstractPathHelpers.DeleteSidecarFileAsync(existingCiphertextName, ciphertextSourceModifiableFolder, specifics, cancellationToken);
+            await AbstractPathHelpers.DeleteSidecarFileAsync(existingCiphertextName, ciphertextSourceModifiableFolder, cancellationToken);
 
             return (IChildFile)Wrap(movedCiphertextFile, newName);
         }

--- a/src/Core/SecureFolderFS.Core.FileSystem/Storage/CryptoFolder.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Storage/CryptoFolder.cs
@@ -51,12 +51,15 @@ namespace SecureFolderFS.Core.FileSystem.Storage
                 throw new NotSupportedException("Renaming folder contents is not supported.");
 
             // We need to get the equivalent on the disk
-            var ciphertextName = await AbstractPathHelpers.EncryptNameAsync(storable.Name, Inner, specifics, cancellationToken);
+            var ciphertextName = await AbstractPathHelpers.EncryptNameForDiscoveryAsync(storable.Name, Inner, specifics, cancellationToken);
             var ciphertextItem = await Inner.GetFirstByNameAsync(ciphertextName, cancellationToken);
 
             // Encrypt name
-            var newCiphertextName = await AbstractPathHelpers.EncryptNameAsync(newName, Inner, specifics, cancellationToken);
+            var newCiphertextName = await AbstractPathHelpers.EncryptNameForUseAsync(newName, Inner, specifics, cancellationToken);
             var renamedCiphertextItem = await renamableFolder.RenameAsync(ciphertextItem, newCiphertextName, cancellationToken);
+
+            // Clean up old sidecar if the old name was shortened
+            await AbstractPathHelpers.DeleteSidecarFileAsync(ciphertextName, renamableFolder, specifics, cancellationToken);
 
             var plaintextId = Path.Combine(Inner.Id, newName);
             return renamedCiphertextItem switch
@@ -91,7 +94,7 @@ namespace SecureFolderFS.Core.FileSystem.Storage
         /// <inheritdoc/>
         public virtual async Task<IStorableChild> GetFirstByNameAsync(string name, CancellationToken cancellationToken = default)
         {
-            var ciphertextName = await AbstractPathHelpers.EncryptNameAsync(name, Inner, specifics, cancellationToken);
+            var ciphertextName = await AbstractPathHelpers.EncryptNameForDiscoveryAsync(name, Inner, specifics, cancellationToken);
             return await Inner.GetFirstByNameAsync(ciphertextName, cancellationToken) switch
             {
                 IChildFile file => (IStorableChild)Wrap(file, name),
@@ -123,7 +126,7 @@ namespace SecureFolderFS.Core.FileSystem.Storage
                 throw new NotSupportedException("Modifying folder contents is not supported.");
 
             // We need to get the equivalent on the disk
-            var ciphertextName = await AbstractPathHelpers.EncryptNameAsync(item.Name, Inner, specifics, cancellationToken);
+            var ciphertextName = await AbstractPathHelpers.EncryptNameForDiscoveryAsync(item.Name, Inner, specifics, cancellationToken);
             var ciphertextItem = await Inner.GetFirstByNameAsync(ciphertextName, cancellationToken);
 
             if (deleteImmediately)
@@ -136,6 +139,9 @@ namespace SecureFolderFS.Core.FileSystem.Storage
                 // Delete or recycle the ciphertext item
                 await AbstractRecycleBinHelpers.DeleteOrRecycleAsync(modifiableFolder, ciphertextItem, specifics, StreamSerializer.Instance, sizeHint, cancellationToken: cancellationToken);
             }
+
+            // Clean up old sidecar if the old name was shortened
+            await AbstractPathHelpers.DeleteSidecarFileAsync(ciphertextName, modifiableFolder, specifics, cancellationToken);
 
             // Remove deleted directory from cache
             if (ciphertextItem is IFolder)
@@ -244,7 +250,7 @@ namespace SecureFolderFS.Core.FileSystem.Storage
                 return await fallback(this, fileToMove, source, overwrite, newName, cancellationToken);
 
             // Get the ciphertext representation of the file to move
-            var existingCiphertextName = await AbstractPathHelpers.EncryptNameAsync(fileToMove.Name, ciphertextSource, specifics, cancellationToken);
+            var existingCiphertextName = await AbstractPathHelpers.EncryptNameForDiscoveryAsync(fileToMove.Name, ciphertextSource, specifics, cancellationToken);
             var ciphertextFileToMove = await ciphertextSource.TryGetFileByNameAsync(existingCiphertextName, cancellationToken);
             if (ciphertextFileToMove is null)
                 return await fallback(this, fileToMove, source, overwrite, newName, cancellationToken);
@@ -254,6 +260,10 @@ namespace SecureFolderFS.Core.FileSystem.Storage
 
             // Move the ciphertext file
             var movedCiphertextFile = await moveRenamedFrom.MoveFromAsync(ciphertextFileToMove, ciphertextSourceModifiableFolder, overwrite, newCiphertextName, cancellationToken, fallback);
+
+            // Clean up old sidecar if the old name was shortened
+            await AbstractPathHelpers.DeleteSidecarFileAsync(existingCiphertextName, ciphertextSourceModifiableFolder, specifics, cancellationToken);
+
             return (IChildFile)Wrap(movedCiphertextFile, newName);
         }
 
@@ -279,10 +289,10 @@ namespace SecureFolderFS.Core.FileSystem.Storage
                 if (folderWrapper.GetWrapperAt<IFolder, CryptoFolder>() is not { Inner: var ciphertextRoot })
                     return null;
 
-                if (parentFolder.Id == Path.DirectorySeparatorChar.ToString())
+                if (parentFolder.Id == Path.DirectorySeparatorChar.ToString() || parentFolder.Id == specifics.ContentFolder.Id)
                     return ciphertextRoot as TStorable;
 
-                var ciphertextName = await AbstractPathHelpers.EncryptNameAsync(item.Name, ciphertextRoot, specifics, cancellationToken);
+                var ciphertextName = await AbstractPathHelpers.EncryptNameForDiscoveryAsync(item.Name, ciphertextRoot, specifics, cancellationToken);
                 return await ciphertextRoot.TryGetFirstByNameAsync(ciphertextName, cancellationToken) as TStorable;
             }
 
@@ -292,7 +302,7 @@ namespace SecureFolderFS.Core.FileSystem.Storage
             if (parentFolderWrapper.GetWrapperAt<IFolder, CryptoFolder>() is not { Inner: var ciphertextParent })
                 return null;
 
-            var ciphertextName2 = await AbstractPathHelpers.EncryptNameAsync(item.Name, ciphertextParent, specifics, cancellationToken);
+            var ciphertextName2 = await AbstractPathHelpers.EncryptNameForDiscoveryAsync(item.Name, ciphertextParent, specifics, cancellationToken);
             return await ciphertextParent.TryGetFirstByNameAsync(ciphertextName2, cancellationToken) as TStorable;
         }
     }

--- a/src/Core/SecureFolderFS.Core.FileSystem/Validators/BaseFileSystemValidator.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Validators/BaseFileSystemValidator.cs
@@ -60,6 +60,11 @@ namespace SecureFolderFS.Core.FileSystem.Validators
             if (!string.IsNullOrEmpty(decryptedName))
                 return decryptedName;
 
+            // A shortened file (.sffsn) that couldn't be decrypted means its sidecar is missing.
+            // Report this as an invalid name so the health system can offer to generate a new one.
+            if (storable.Name.EndsWith(Constants.Names.SHORTENED_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase))
+                return null;
+
             // We want to suppress failures that might be raised when the Directory ID file is not found.
             // This case should be already handled in the folder validator
 

--- a/src/Core/SecureFolderFS.Core.FileSystem/Validators/StructureContentsValidator.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Validators/StructureContentsValidator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using OwlCore.Storage;
+using SecureFolderFS.Core.FileSystem.Helpers.Health;
 using SecureFolderFS.Core.FileSystem.Helpers.Paths;
 using SecureFolderFS.Shared.ComponentModel;
 using SecureFolderFS.Shared.Models;
@@ -35,6 +36,10 @@ namespace SecureFolderFS.Core.FileSystem.Validators
 
             var folderResult = await _folderValidator.ValidateResultAsync(scannedFolder, cancellationToken).ConfigureAwait(false);
             reporter?.Report(folderResult);
+
+            // Detect orphan sidecar files
+            if (specifics.Options.ShorteningThreshold > 0)
+                await HealthHelpers.DetectOrphanSidecarsAsync(scannedFolder, reporter, cancellationToken).ConfigureAwait(false);
 
             await foreach (var item in scannedFolder.GetItemsAsync(StorableType.All, cancellationToken).ConfigureAwait(false))
             {

--- a/src/Core/SecureFolderFS.Core.FileSystem/Validators/StructureValidator.cs
+++ b/src/Core/SecureFolderFS.Core.FileSystem/Validators/StructureValidator.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using OwlCore.Storage;
+using SecureFolderFS.Core.FileSystem.Helpers.Health;
 using SecureFolderFS.Core.FileSystem.Helpers.Paths;
 using SecureFolderFS.Shared.ComponentModel;
 using SecureFolderFS.Shared.Models;
@@ -36,6 +37,10 @@ namespace SecureFolderFS.Core.FileSystem.Validators
 
             if (!folderResult.Successful)
                 return folderResult;
+
+            // Detect orphan sidecar files
+            if (specifics.Options.ShorteningThreshold > 0)
+                await HealthHelpers.DetectOrphanSidecarsAsync(scannedFolder, reporter, cancellationToken).ConfigureAwait(false);
 
             await foreach (var item in scannedFolder.GetItemsAsync(StorableType.All, cancellationToken).ConfigureAwait(false))
             {

--- a/src/Core/SecureFolderFS.Core.WebDav/AppModels/WebDavOptions.cs
+++ b/src/Core/SecureFolderFS.Core.WebDav/AppModels/WebDavOptions.cs
@@ -1,8 +1,8 @@
-﻿using SecureFolderFS.Core.FileSystem.AppModels;
+﻿using System;
+using System.Collections.Generic;
+using SecureFolderFS.Core.FileSystem.AppModels;
 using SecureFolderFS.Shared.Extensions;
 using SecureFolderFS.Storage.VirtualFileSystem;
-using System;
-using System.Collections.Generic;
 
 namespace SecureFolderFS.Core.WebDav.AppModels
 {
@@ -49,6 +49,7 @@ namespace SecureFolderFS.Core.WebDav.AppModels
                 IsCachingFileNames = (bool?)options.Get(nameof(IsCachingFileNames)) ?? true,
                 IsCachingDirectoryIds = (bool?)options.Get(nameof(IsCachingDirectoryIds)) ?? true,
                 RecycleBinSize = (long?)options.Get(nameof(RecycleBinSize)) ?? 0L,
+                ShorteningThreshold = (int?)options.Get(nameof(ShorteningThreshold)) ?? 0,
 
                 // WebDav specific
                 Protocol = (string?)options.Get(nameof(Protocol)) ?? "http",

--- a/src/Core/SecureFolderFS.Core.WinFsp/AppModels/WinFspOptions.cs
+++ b/src/Core/SecureFolderFS.Core.WinFsp/AppModels/WinFspOptions.cs
@@ -1,8 +1,8 @@
-﻿using SecureFolderFS.Core.FileSystem.AppModels;
+﻿using System;
+using System.Collections.Generic;
+using SecureFolderFS.Core.FileSystem.AppModels;
 using SecureFolderFS.Shared.Extensions;
 using SecureFolderFS.Storage.VirtualFileSystem;
-using System;
-using System.Collections.Generic;
 
 namespace SecureFolderFS.Core.WinFsp.AppModels
 {
@@ -36,6 +36,7 @@ namespace SecureFolderFS.Core.WinFsp.AppModels
                 IsCachingFileNames = (bool?)options.Get(nameof(IsCachingFileNames)) ?? true,
                 IsCachingDirectoryIds = (bool?)options.Get(nameof(IsCachingDirectoryIds)) ?? true,
                 RecycleBinSize = (long?)options.Get(nameof(RecycleBinSize)) ?? 0L,
+                ShorteningThreshold = (int?)options.Get(nameof(ShorteningThreshold)) ?? 0,
 
                 // WinFsp specific
                 MountPoint = (string?)options.Get(nameof(MountPoint))

--- a/src/Core/SecureFolderFS.Core.WinFsp/Callbacks/OnDeviceWinFsp.Helpers.cs
+++ b/src/Core/SecureFolderFS.Core.WinFsp/Callbacks/OnDeviceWinFsp.Helpers.cs
@@ -15,6 +15,12 @@ namespace SecureFolderFS.Core.WinFsp.Callbacks
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private string GetCiphertextPathForUse(string plaintextName)
+        {
+            return NativePathHelpers.GetCiphertextPathForUse(plaintextName, _specifics);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsDirectory(string ciphertextPath)
         {
             return Directory.Exists(ciphertextPath) && !File.Exists(ciphertextPath);

--- a/src/Core/SecureFolderFS.Core.WinFsp/Callbacks/OnDeviceWinFsp.cs
+++ b/src/Core/SecureFolderFS.Core.WinFsp/Callbacks/OnDeviceWinFsp.cs
@@ -683,7 +683,7 @@ namespace SecureFolderFS.Core.WinFsp.Callbacks
             IDisposable? handle = null;
             try
             {
-                var ciphertextPath = GetCiphertextPath(FileName);
+                var ciphertextPath = GetCiphertextPathForUse(FileName);
                 if ((CreateOptions & FILE_DIRECTORY_FILE) == 0)
                 {
                     FileSecurity? fileSecurity = null;
@@ -926,6 +926,12 @@ namespace SecureFolderFS.Core.WinFsp.Callbacks
 
                 // Then delete
                 NativeRecycleBinHelpers.DeleteOrRecycle(pathToDelete, _specifics, storableType);
+
+                // Clean up sidecar after successful delete/recycle
+                NativePathHelpers.DeleteSidecarFile(
+                    Path.GetFileName(pathToDelete),
+                    Path.GetDirectoryName(pathToDelete) ?? string.Empty);
+
                 Trace(STATUS_SUCCESS, FileName);
             }
             catch (Exception)
@@ -998,7 +1004,7 @@ namespace SecureFolderFS.Core.WinFsp.Callbacks
                 return Trace(STATUS_ACCESS_DENIED, FileName);
 
             var oldCiphertextPath = GetCiphertextPath(FileName);
-            var newCiphertextPath = GetCiphertextPath(NewFileName);
+            var newCiphertextPath = GetCiphertextPathForUse(NewFileName);
             var isDirectory = IsDirectory(oldCiphertextPath);
             var newPathExists = isDirectory ? Directory.Exists(newCiphertextPath) : File.Exists(newCiphertextPath);
 
@@ -1015,6 +1021,11 @@ namespace SecureFolderFS.Core.WinFsp.Callbacks
                         File.Move(oldCiphertextPath, newCiphertextPath);
                     }
 
+                    // Clean up old sidecar after successful move
+                    NativePathHelpers.DeleteSidecarFile(
+                        Path.GetFileName(oldCiphertextPath),
+                        Path.GetDirectoryName(oldCiphertextPath) ?? string.Empty);
+
                     return Trace(STATUS_SUCCESS, FileName);
                 }
                 else if (ReplaceIfExists)
@@ -1027,6 +1038,11 @@ namespace SecureFolderFS.Core.WinFsp.Callbacks
 
                     File.Delete(newCiphertextPath);
                     File.Move(oldCiphertextPath, newCiphertextPath);
+
+                    // Clean up old sidecar after successful move
+                    NativePathHelpers.DeleteSidecarFile(
+                        Path.GetFileName(oldCiphertextPath),
+                        Path.GetDirectoryName(oldCiphertextPath) ?? string.Empty);
 
                     return Trace(STATUS_SUCCESS, FileName);
                 }

--- a/src/Core/SecureFolderFS.Core/Constants.cs
+++ b/src/Core/SecureFolderFS.Core/Constants.cs
@@ -45,6 +45,7 @@ namespace SecureFolderFS.Core
                 public const string ASSOC_CONTENT_CIPHER_ID = "contentCipherScheme";
                 public const string ASSOC_FILENAME_CIPHER_ID = "filenameCipherScheme";
                 public const string ASSOC_FILENAME_ENCODING_ID = "filenameEncoding";
+                public const string ASSOC_FILENAME_SHORTENING = "filenameShortening";
                 public const string ASSOC_RECYCLE_SIZE = "recycleBinSize";
                 public const string ASSOC_AUTHENTICATION = "authMode";
                 public const string ASSOC_VAULT_ID = "vaultId";

--- a/src/Core/SecureFolderFS.Core/DataModels/V4VaultConfigurationDataModel.cs
+++ b/src/Core/SecureFolderFS.Core/DataModels/V4VaultConfigurationDataModel.cs
@@ -29,7 +29,14 @@ namespace SecureFolderFS.Core.DataModels
         /// </summary>
         [JsonPropertyName(Associations.ASSOC_FILENAME_ENCODING_ID)]
         [DefaultValue("")]
-        public string FileNameEncodingId { get; set; } = Cryptography.Constants.CipherId.ENCODING_BASE64URL;
+        public required string FileNameEncodingId { get; set; } = Cryptography.Constants.CipherId.ENCODING_BASE64URL;
+
+        /// <summary>
+        /// Gets the threshold for shortening file names.
+        /// </summary>
+        [JsonPropertyName(Associations.ASSOC_FILENAME_SHORTENING)]
+        [DefaultValue(0)]
+        public required int ShorteningThreshold { get; init; }
 
         /// <summary>
         /// Gets the size of the recycle bin.
@@ -77,6 +84,7 @@ namespace SecureFolderFS.Core.DataModels
                 ContentCipherId = vaultOptions.ContentCipherId ?? Cryptography.Constants.CipherId.XCHACHA20_POLY1305,
                 FileNameCipherId = vaultOptions.FileNameCipherId ?? Cryptography.Constants.CipherId.AES_SIV,
                 FileNameEncodingId = vaultOptions.NameEncodingId ?? Cryptography.Constants.CipherId.ENCODING_BASE64URL,
+                ShorteningThreshold = vaultOptions.ShorteningThreshold,
                 AuthenticationMethod = vaultOptions.UnlockProcedure.ToString(),
                 RecycleBinSize = vaultOptions.RecycleBinSize,
                 Uid = vaultOptions.VaultId ?? Guid.NewGuid().ToString(),

--- a/src/Core/SecureFolderFS.Core/Models/SecurityWrapper.cs
+++ b/src/Core/SecureFolderFS.Core/Models/SecurityWrapper.cs
@@ -31,6 +31,7 @@ namespace SecureFolderFS.Core.Models
         public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
         {
             yield return new(nameof(VirtualFileSystemOptions.RecycleBinSize), _configDataModel.RecycleBinSize);
+            yield return new (nameof(VirtualFileSystemOptions.ShorteningThreshold), _configDataModel.ShorteningThreshold);
         }
 
         /// <inheritdoc/>

--- a/src/Core/SecureFolderFS.Core/Routines/Operational/ModifyComplementationRoutine.cs
+++ b/src/Core/SecureFolderFS.Core/Routines/Operational/ModifyComplementationRoutine.cs
@@ -37,8 +37,8 @@ namespace SecureFolderFS.Core.Routines.Operational
         /// <inheritdoc/>
         public async Task InitAsync(CancellationToken cancellationToken = default)
         {
-            _existingConfigDataModel = await _vaultReader.ReadV4ConfigurationAsync(cancellationToken);
-            _existingKeystoreDataModel = await _vaultReader.ReadKeystoreAsync<V4VaultKeystoreDataModel>(cancellationToken);
+            _existingConfigDataModel = await _vaultReader.ReadConfigurationAsync(cancellationToken);
+            _existingKeystoreDataModel = await _vaultReader.ReadKeystoreAsync(cancellationToken);
             _existingSharesDataModel = await _vaultReader.ReadComplementationAsync(cancellationToken);
         }
 

--- a/src/Core/SecureFolderFS.Core/Routines/Operational/ModifyCredentialsRoutine.cs
+++ b/src/Core/SecureFolderFS.Core/Routines/Operational/ModifyCredentialsRoutine.cs
@@ -32,7 +32,7 @@ namespace SecureFolderFS.Core.Routines.Operational
         /// <inheritdoc/>
         public async Task InitAsync(CancellationToken cancellationToken = default)
         {
-            _existingV4KeystoreDataModel = await _vaultReader.ReadKeystoreAsync<V4VaultKeystoreDataModel>(cancellationToken);
+            _existingV4KeystoreDataModel = await _vaultReader.ReadKeystoreAsync(cancellationToken);
         }
 
         /// <inheritdoc/>

--- a/src/Core/SecureFolderFS.Core/Routines/Operational/RecoverRoutine.cs
+++ b/src/Core/SecureFolderFS.Core/Routines/Operational/RecoverRoutine.cs
@@ -25,7 +25,7 @@ namespace SecureFolderFS.Core.Routines.Operational
         /// <inheritdoc/>
         public async Task InitAsync(CancellationToken cancellationToken)
         {
-            _configDataModel = await _vaultReader.ReadV4ConfigurationAsync(cancellationToken);
+            _configDataModel = await _vaultReader.ReadConfigurationAsync(cancellationToken);
         }
 
         /// <inheritdoc/>

--- a/src/Core/SecureFolderFS.Core/Routines/Operational/RestoreRoutine.cs
+++ b/src/Core/SecureFolderFS.Core/Routines/Operational/RestoreRoutine.cs
@@ -73,9 +73,16 @@ namespace SecureFolderFS.Core.Routines.Operational
             var minSidecarContentLength = int.MaxValue;
             var hasShortenedNames = false;
 
-            var folderScanner = new DeepFolderScanner(contentFolder, StorableType.File);
+            var folderScanner = new DeepFolderScanner(contentFolder, StorableType.All);
             await foreach (var item in folderScanner.ScanFolderAsync(cancellationToken))
             {
+                // Shortened items are hashes that can't be decrypted directly
+                if (item.Name.EndsWith(FileSystem.Constants.Names.SHORTENED_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase))
+                {
+                    hasShortenedNames = true;
+                    continue;
+                }
+
                 if (item is not IFile file)
                     continue;
 
@@ -92,13 +99,6 @@ namespace SecureFolderFS.Core.Routines.Operational
                     }
                     catch { }
 
-                    continue;
-                }
-
-                // Shortened files are hashes that can't be decrypted directly
-                if (item.Name.EndsWith(FileSystem.Constants.Names.SHORTENED_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase))
-                {
-                    hasShortenedNames = true;
                     continue;
                 }
 

--- a/src/Core/SecureFolderFS.Core/Routines/Operational/RestoreRoutine.cs
+++ b/src/Core/SecureFolderFS.Core/Routines/Operational/RestoreRoutine.cs
@@ -76,6 +76,8 @@ namespace SecureFolderFS.Core.Routines.Operational
             var folderScanner = new DeepFolderScanner(contentFolder, StorableType.All);
             await foreach (var item in folderScanner.ScanFolderAsync(cancellationToken))
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 // Shortened items are hashes that can't be decrypted directly
                 if (item.Name.EndsWith(FileSystem.Constants.Names.SHORTENED_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase))
                 {
@@ -91,13 +93,17 @@ namespace SecureFolderFS.Core.Routines.Operational
                 {
                     try
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
                         await using var sidecarStream = await file.OpenReadAsync(cancellationToken);
                         var buffer = new byte[4097];
                         var bytesRead = await sidecarStream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken);
                         if (bytesRead is > 0 and <= 4096)
                             minSidecarContentLength = Math.Min(minSidecarContentLength, Encoding.UTF8.GetString(buffer, 0, bytesRead).Length);
                     }
-                    catch { }
+                    catch
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
 
                     continue;
                 }

--- a/src/Core/SecureFolderFS.Core/Routines/Operational/RestoreRoutine.cs
+++ b/src/Core/SecureFolderFS.Core/Routines/Operational/RestoreRoutine.cs
@@ -69,12 +69,16 @@ namespace SecureFolderFS.Core.Routines.Operational
             string? foundNameCrypt = null;
             string? foundEncoding = null;
             var noExtensions = 0;
+            var shorteningThreshold = 0;
 
             var folderScanner = new DeepFolderScanner(contentFolder, StorableType.File);
             await foreach (var item in folderScanner.ScanFolderAsync(cancellationToken))
             {
                 if (item is not IFile file)
                     continue;
+
+                if (shorteningThreshold == 0 && item.Name.EndsWith(FileSystem.Constants.Names.SHORTENED_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase))
+                    shorteningThreshold = 220; // Arbitrary threshold typical for shortened names
 
                 if (!item.Name.EndsWith(FileSystem.Constants.Names.ENCRYPTED_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase))
                     noExtensions++;
@@ -106,6 +110,7 @@ namespace SecureFolderFS.Core.Routines.Operational
                 ContentCipherId = foundContentCrypt,
                 FileNameCipherId = foundNameCrypt,
                 FileNameEncodingId = foundEncoding,
+                ShorteningThreshold = shorteningThreshold,
                 RecycleBinSize = 0L,
                 Uid = Guid.NewGuid().ToString(),
                 Version = Constants.Vault.Versions.LATEST_VERSION,

--- a/src/Core/SecureFolderFS.Core/Routines/Operational/RestoreRoutine.cs
+++ b/src/Core/SecureFolderFS.Core/Routines/Operational/RestoreRoutine.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using OwlCore.Storage;
@@ -69,7 +70,8 @@ namespace SecureFolderFS.Core.Routines.Operational
             string? foundNameCrypt = null;
             string? foundEncoding = null;
             var noExtensions = 0;
-            var shorteningThreshold = 0;
+            var minSidecarContentLength = int.MaxValue;
+            var hasShortenedNames = false;
 
             var folderScanner = new DeepFolderScanner(contentFolder, StorableType.File);
             await foreach (var item in folderScanner.ScanFolderAsync(cancellationToken))
@@ -77,8 +79,28 @@ namespace SecureFolderFS.Core.Routines.Operational
                 if (item is not IFile file)
                     continue;
 
-                if (shorteningThreshold == 0 && item.Name.EndsWith(FileSystem.Constants.Names.SHORTENED_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase))
-                    shorteningThreshold = 220; // Arbitrary threshold typical for shortened names
+                // Read sidecar files to determine the shortening threshold from the actual ciphertext name length
+                if (item.Name.EndsWith(FileSystem.Constants.Names.SIDECAR_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase))
+                {
+                    try
+                    {
+                        await using var sidecarStream = await file.OpenReadAsync(cancellationToken);
+                        var buffer = new byte[4097];
+                        var bytesRead = await sidecarStream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken);
+                        if (bytesRead is > 0 and <= 4096)
+                            minSidecarContentLength = Math.Min(minSidecarContentLength, Encoding.UTF8.GetString(buffer, 0, bytesRead).Length);
+                    }
+                    catch { }
+
+                    continue;
+                }
+
+                // Shortened files are hashes that can't be decrypted directly
+                if (item.Name.EndsWith(FileSystem.Constants.Names.SHORTENED_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase))
+                {
+                    hasShortenedNames = true;
+                    continue;
+                }
 
                 if (!item.Name.EndsWith(FileSystem.Constants.Names.ENCRYPTED_FILE_EXTENSION, StringComparison.OrdinalIgnoreCase))
                     noExtensions++;
@@ -101,6 +123,11 @@ namespace SecureFolderFS.Core.Routines.Operational
 
             if (foundNameCrypt is null || foundEncoding is null || foundContentCrypt is null)
                 throw new InvalidOperationException("Could not find all required cryptographic components.");
+
+            // Determine shortening threshold from sidecar content, with fallback for missing sidecars
+            var shorteningThreshold = minSidecarContentLength < int.MaxValue
+                ? minSidecarContentLength
+                : hasShortenedNames ? 220 : 0;
 
             // Regenerate config
             var configDataModel = new V4VaultConfigurationDataModel()

--- a/src/Core/SecureFolderFS.Core/Routines/Operational/UnlockRoutine.cs
+++ b/src/Core/SecureFolderFS.Core/Routines/Operational/UnlockRoutine.cs
@@ -32,8 +32,8 @@ namespace SecureFolderFS.Core.Routines.Operational
         /// <inheritdoc/>
         public async Task InitAsync(CancellationToken cancellationToken)
         {
-            _configDataModel = await _vaultReader.ReadV4ConfigurationAsync(cancellationToken);
-            _keystoreDataModel = await _vaultReader.ReadKeystoreAsync<V4VaultKeystoreDataModel>(cancellationToken);
+            _configDataModel = await _vaultReader.ReadConfigurationAsync(cancellationToken);
+            _keystoreDataModel = await _vaultReader.ReadKeystoreAsync(cancellationToken);
             _sharesDataModel = await _vaultReader.ReadComplementationAsync(cancellationToken);
         }
 

--- a/src/Core/SecureFolderFS.Core/VaultAccess/VaultParser.cs
+++ b/src/Core/SecureFolderFS.Core/VaultAccess/VaultParser.cs
@@ -43,13 +43,14 @@ namespace SecureFolderFS.Core.VaultAccess
             hmacSha256.AppendData(BitConverter.GetBytes(CryptHelpers.ContentCipherId(configDataModel.ContentCipherId)));
             hmacSha256.AppendData(BitConverter.GetBytes(CryptHelpers.FileNameCipherId(configDataModel.FileNameCipherId)));
             hmacSha256.AppendData(BitConverter.GetBytes(configDataModel.RecycleBinSize));
+            hmacSha256.AppendData(BitConverter.GetBytes(configDataModel.ShorteningThreshold));
             hmacSha256.AppendData(Encoding.UTF8.GetBytes(configDataModel.FileNameEncodingId));
             hmacSha256.AppendData(Encoding.UTF8.GetBytes(configDataModel.Uid));
-            hmacSha256.AppendData(Encoding.UTF8.GetBytes(configDataModel.AppPlatform?.ServerUrl ?? string.Empty));
-            hmacSha256.AppendData(Encoding.UTF8.GetBytes(configDataModel.AppPlatform?.VaultResource ?? string.Empty));
-            hmacSha256.AppendData(Encoding.UTF8.GetBytes(configDataModel.AppPlatform?.Organization ?? string.Empty));
-            hmacSha256.AppendData(Encoding.UTF8.GetBytes(configDataModel.AppPlatform?.AccessTokenEndpoint ?? string.Empty));
-            hmacSha256.AppendData(Encoding.UTF8.GetBytes(configDataModel.AppPlatform?.DeviceRegistrationEndpoint ?? string.Empty));
+            // hmacSha256.AppendData(Encoding.UTF8.GetBytes(configDataModel.AppPlatform?.ServerUrl ?? string.Empty));
+            // hmacSha256.AppendData(Encoding.UTF8.GetBytes(configDataModel.AppPlatform?.VaultResource ?? string.Empty));
+            // hmacSha256.AppendData(Encoding.UTF8.GetBytes(configDataModel.AppPlatform?.Organization ?? string.Empty));
+            // hmacSha256.AppendData(Encoding.UTF8.GetBytes(configDataModel.AppPlatform?.AccessTokenEndpoint ?? string.Empty));
+            // hmacSha256.AppendData(Encoding.UTF8.GetBytes(configDataModel.AppPlatform?.DeviceRegistrationEndpoint ?? string.Empty));
             hmacSha256.AppendFinalData(Encoding.UTF8.GetBytes(configDataModel.AuthenticationMethod));
 
             hmacSha256.GetCurrentHash(mac);

--- a/src/Core/SecureFolderFS.Core/VaultAccess/VaultReader.cs
+++ b/src/Core/SecureFolderFS.Core/VaultAccess/VaultReader.cs
@@ -23,6 +23,16 @@ namespace SecureFolderFS.Core.VaultAccess
             _serializer = serializer;
         }
 
+        public async Task<V4VaultConfigurationDataModel> ReadConfigurationAsync(CancellationToken cancellationToken)
+        {
+            return await ReadConfigurationAsync<V4VaultConfigurationDataModel>(cancellationToken);
+        }
+
+        public async Task<V4VaultKeystoreDataModel> ReadKeystoreAsync(CancellationToken cancellationToken)
+        {
+            return await ReadKeystoreAsync<V4VaultKeystoreDataModel>(cancellationToken);
+        }
+
         /// <summary>
         /// Reads the keystore as the specified type.
         /// </summary>
@@ -34,17 +44,15 @@ namespace SecureFolderFS.Core.VaultAccess
             return await ReadDataAsync<TKeystore>(keystoreFile, _serializer, cancellationToken);
         }
 
-        public async Task<VaultConfigurationDataModel> ReadConfigurationAsync(CancellationToken cancellationToken)
+        /// <summary>
+        /// Reads the configuration file as the specified type.
+        /// </summary>
+        public async Task<TConfiguration> ReadConfigurationAsync<TConfiguration>(CancellationToken cancellationToken)
+            where TConfiguration : class
         {
             // Get configuration file
             var configFile = await _vaultFolder.GetFileByNameAsync(Constants.Vault.Names.VAULT_CONFIGURATION_FILENAME, cancellationToken);
-            return await ReadDataAsync<VaultConfigurationDataModel>(configFile, _serializer, cancellationToken);
-        }
-
-        public async Task<V4VaultConfigurationDataModel> ReadV4ConfigurationAsync(CancellationToken cancellationToken)
-        {
-            var configFile = await _vaultFolder.GetFileByNameAsync(Constants.Vault.Names.VAULT_CONFIGURATION_FILENAME, cancellationToken);
-            return await ReadDataAsync<V4VaultConfigurationDataModel>(configFile, _serializer, cancellationToken);
+            return await ReadDataAsync<TConfiguration>(configFile, _serializer, cancellationToken);
         }
 
         public async Task<VaultSharesDataModel?> ReadComplementationAsync(CancellationToken cancellationToken)

--- a/src/Core/SecureFolderFS.Core/VaultAccess/VaultWriter.cs
+++ b/src/Core/SecureFolderFS.Core/VaultAccess/VaultWriter.cs
@@ -36,7 +36,8 @@ namespace SecureFolderFS.Core.VaultAccess
             await WriteDataAsync(keystoreFile, keystoreDataModel, cancellationToken);
         }
 
-        public async Task WriteConfigurationAsync(VaultConfigurationDataModel? configDataModel, CancellationToken cancellationToken)
+        public async Task WriteConfigurationAsync<TConfiguration>(TConfiguration? configDataModel, CancellationToken cancellationToken)
+            where TConfiguration : class
         {
             var configFile = configDataModel is null ? null : _vaultFolder switch
             {

--- a/src/Platforms/SecureFolderFS.Maui/Extensions/Mappers/CustomMappers.Entry.cs
+++ b/src/Platforms/SecureFolderFS.Maui/Extensions/Mappers/CustomMappers.Entry.cs
@@ -17,7 +17,7 @@ namespace SecureFolderFS.Maui.Extensions.Mappers
         {
             EntryHandler.Mapper.AppendToMapping($"{nameof(CustomMappers)}.{nameof(Entry)}", (handler, view) =>
             {
-                if (view is not ModernEntry)
+                if (view is not ModernEntry modernEntry)
                     return;
 #if ANDROID
                 const float R = 24f;
@@ -33,7 +33,11 @@ namespace SecureFolderFS.Maui.Extensions.Mappers
                 shape.Paint.StrokeWidth = 4;
                 shape.Paint.SetStyle(Paint.Style.Stroke);
                 handler.PlatformView.Background = shape;
-                handler.PlatformView.SetPadding(40, 32,40, 32);
+                
+                if (modernEntry.IsPadded)
+                    handler.PlatformView.SetPadding(40, 32,40, 32);
+                else
+                    handler.PlatformView.SetPadding(16, 8, 16, 8);
 #elif IOS
                 handler.PlatformView.Layer.BorderColor = (App.Current.Resources[MauiThemeHelper.Instance.ActualTheme switch
                 {

--- a/src/Platforms/SecureFolderFS.Maui/UserControls/Common/ModernEntry.cs
+++ b/src/Platforms/SecureFolderFS.Maui/UserControls/Common/ModernEntry.cs
@@ -2,5 +2,12 @@ namespace SecureFolderFS.Maui.UserControls.Common
 {
     public class ModernEntry : Entry
     {
+        public bool IsPadded
+        {
+            get => (bool)GetValue(IsPaddedProperty);
+            set => SetValue(IsPaddedProperty, value);
+        }
+        public static readonly BindableProperty IsPaddedProperty =
+            BindableProperty.Create(nameof(IsPadded), typeof(bool), typeof(ModernEntry), defaultValue: true);
     }
 }

--- a/src/Platforms/SecureFolderFS.Maui/Views/Modals/Wizard/CredentialsWizardPage.xaml
+++ b/src/Platforms/SecureFolderFS.Maui/Views/Modals/Wizard/CredentialsWizardPage.xaml
@@ -81,10 +81,7 @@
                                             SelectedItem="{Binding ViewModel.FileNameCipher, Mode=TwoWay}" />
                                     </uco:OptionsControl.Slot>
                                 </uco:OptionsControl>
-                                <uco:OptionsControl
-                                    Title="{l:ResourceString Rid=NameEncoding}"
-                                    IsSeparatorVisible="False"
-                                    IsVisible="{Binding ViewModel.IsNameCipherEnabled, Mode=OneWay}">
+                                <uco:OptionsControl Title="{l:ResourceString Rid=NameEncoding}" IsVisible="{Binding ViewModel.IsNameCipherEnabled, Mode=OneWay}">
                                     <uco:OptionsControl.Slot>
                                         <ucc:ModernPicker
                                             HorizontalTextAlignment="End"
@@ -93,6 +90,24 @@
                                             ItemsSource="{Binding ViewModel.EncodingOptions, Mode=OneWay}"
                                             MinimumWidthRequest="110"
                                             SelectedItem="{Binding ViewModel.EncodingOption, Mode=TwoWay}" />
+                                    </uco:OptionsControl.Slot>
+                                </uco:OptionsControl>
+                                <uco:OptionsControl
+                                    Title="{l:ResourceString Rid=NameShortening}"
+                                    IsSeparatorVisible="False"
+                                    IsVisible="{Binding ViewModel.IsNameCipherEnabled, Mode=OneWay}">
+                                    <uco:OptionsControl.Slot>
+                                        <ucc:ModernEntry
+                                            HeightRequest="32"
+                                            HorizontalTextAlignment="End"
+                                            IsPadded="False"
+                                            IsSpellCheckEnabled="False"
+                                            IsTextPredictionEnabled="False"
+                                            Keyboard="Numeric"
+                                            MaxLength="3"
+                                            Text="0"
+                                            TextChanged="Shortening_TextChanged"
+                                            WidthRequest="72" />
                                     </uco:OptionsControl.Slot>
                                 </uco:OptionsControl>
                             </VerticalStackLayout>

--- a/src/Platforms/SecureFolderFS.Maui/Views/Modals/Wizard/CredentialsWizardPage.xaml.cs
+++ b/src/Platforms/SecureFolderFS.Maui/Views/Modals/Wizard/CredentialsWizardPage.xaml.cs
@@ -24,5 +24,18 @@ namespace SecureFolderFS.Maui.Views.Modals.Wizard
             OverlayViewModel.CurrentViewModel = ViewModel;
             base.OnAppearing();
         }
+
+        private void Shortening_TextChanged(object? sender, TextChangedEventArgs e)
+        {
+            if (sender is not Entry entry)
+                return;
+
+            if (!int.TryParse(entry.Text, out var value))
+                value = 0;
+            
+            value = Math.Max(0, Math.Min(value, 250));
+            entry.Text = value.ToString();
+            ViewModel.ShorteningThreshold = value;
+        }
     }
 }

--- a/src/Platforms/SecureFolderFS.UI/ServiceImplementation/RecycleBinService.cs
+++ b/src/Platforms/SecureFolderFS.UI/ServiceImplementation/RecycleBinService.cs
@@ -36,7 +36,7 @@ namespace SecureFolderFS.UI.ServiceImplementation
             var configDataModel = await vaultReader.ReadConfigurationAsync(cancellationToken);
             if (configDataModel.AuthenticationMethod.Contains(Core.Constants.Vault.Authentication.AUTH_APP_PLATFORM, StringComparison.Ordinal))
             {
-                var v4ConfigDataModel = await vaultReader.ReadV4ConfigurationAsync(cancellationToken);
+                var v4ConfigDataModel = await vaultReader.ReadConfigurationAsync(cancellationToken);
                 var newV4ConfigDataModel = v4ConfigDataModel with
                 {
                     RecycleBinSize = maxSize,
@@ -61,7 +61,7 @@ namespace SecureFolderFS.UI.ServiceImplementation
                 // First, we need to fill in the PayloadMac of the content
                 specifics.Security.KeyPair.MacKey.UseKey(macKey =>
                 {
-                    VaultParser.CalculateConfigMac(newConfigDataModel, macKey, newConfigDataModel.PayloadMac);
+                    VaultParser.V4CalculateConfigMac(newConfigDataModel, macKey, newConfigDataModel.PayloadMac);
                 });
 
                 await vaultWriter.WriteConfigurationAsync(newConfigDataModel, cancellationToken);

--- a/src/Platforms/SecureFolderFS.UI/ServiceImplementation/RecycleBinService.cs
+++ b/src/Platforms/SecureFolderFS.UI/ServiceImplementation/RecycleBinService.cs
@@ -34,38 +34,20 @@ namespace SecureFolderFS.UI.ServiceImplementation
 
             // Read configuration
             var configDataModel = await vaultReader.ReadConfigurationAsync(cancellationToken);
-            if (configDataModel.AuthenticationMethod.Contains(Core.Constants.Vault.Authentication.AUTH_APP_PLATFORM, StringComparison.Ordinal))
+            var newConfigDataModel = configDataModel with
             {
-                var v4ConfigDataModel = await vaultReader.ReadConfigurationAsync(cancellationToken);
-                var newV4ConfigDataModel = v4ConfigDataModel with
-                {
-                    RecycleBinSize = maxSize,
-                    PayloadMac = new byte[HMACSHA256.HashSizeInBytes]
-                };
+                RecycleBinSize = maxSize,
+                PayloadMac = new byte[HMACSHA256.HashSizeInBytes]
+            };
 
-                specifics.Security.KeyPair.MacKey.UseKey(macKey =>
-                {
-                    VaultParser.V4CalculateConfigMac(newV4ConfigDataModel, macKey, newV4ConfigDataModel.PayloadMac);
-                });
-
-                await vaultWriter.WriteV4ConfigurationAsync(newV4ConfigDataModel, cancellationToken);
-            }
-            else
+            // First, we need to fill in the PayloadMac of the content
+            specifics.Security.KeyPair.MacKey.UseKey(macKey =>
             {
-                var newConfigDataModel = configDataModel with
-                {
-                    RecycleBinSize = maxSize,
-                    PayloadMac = new byte[HMACSHA256.HashSizeInBytes]
-                };
+                VaultParser.V4CalculateConfigMac(newConfigDataModel, macKey, newConfigDataModel.PayloadMac);
+            });
 
-                // First, we need to fill in the PayloadMac of the content
-                specifics.Security.KeyPair.MacKey.UseKey(macKey =>
-                {
-                    VaultParser.V4CalculateConfigMac(newConfigDataModel, macKey, newConfigDataModel.PayloadMac);
-                });
-
-                await vaultWriter.WriteConfigurationAsync(newConfigDataModel, cancellationToken);
-            }
+            // Then, write the config
+            await vaultWriter.WriteConfigurationAsync(newConfigDataModel, cancellationToken);
 
             // Make sure to also update the file system options
             specifics.Options.DangerousSetRecycleBin(maxSize);

--- a/src/Platforms/SecureFolderFS.UI/ServiceImplementation/VaultHealthService.cs
+++ b/src/Platforms/SecureFolderFS.UI/ServiceImplementation/VaultHealthService.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using OwlCore.Storage;
 using SecureFolderFS.Core.FileSystem;
+using SecureFolderFS.Core.FileSystem.Exceptions;
 using SecureFolderFS.Core.FileSystem.Helpers.Health;
 using SecureFolderFS.Core.FileSystem.Validators;
 using SecureFolderFS.Sdk.Extensions;
@@ -40,6 +41,7 @@ namespace SecureFolderFS.UI.ServiceImplementation
                     _ => GetDefault(aggregate)
                 },
                 FormatException => new HealthNameIssueViewModel(storable, result, "InvalidItemName".ToLocalized()) { ErrorMessage = "GenerateNewName".ToLocalized() },
+                OrphanSidecarException => new HealthOrphanSidecarIssueViewModel(storable, result, "OrphanSidecar".ToLocalized()) { ErrorMessage = "DeleteOrphanSidecar".ToLocalized() },
                 FileHeaderCorruptedException => new HealthFileDataIssueViewModel(storable, result, "IrrecoverableFile".ToLocalized(), isRecoverable: false) { ErrorMessage = "FileHeaderCorrupted".ToLocalized() },
                 FileChunksCorruptedException chunksEx => new HealthFileDataIssueViewModel(storable, result, "CorruptedFileChunks".ToLocalized(), chunksEx.CorruptedChunks, isRecoverable: true) { ErrorMessage = "FileHasCorruptedChunks".ToLocalized(chunksEx.CorruptedChunks.Count) },
                 CryptographicException => new HealthFileDataIssueViewModel(storable, result, "InvalidFileContents".ToLocalized()) { ErrorMessage = "RegenerateFileContents".ToLocalized() },
@@ -90,7 +92,7 @@ namespace SecureFolderFS.UI.ServiceImplementation
                         // Directory ID issue
                         HealthDirectoryIssueViewModel directoryIssue => await HealthHelpers.RepairDirectoryAsync(
                             directoryIssue.Folder ?? throw new ArgumentNullException(nameof(HealthDirectoryIssueViewModel.Folder)),
-                            specificsWrapper.Inner.Security,
+                            specificsWrapper.Inner,
                             cancellationToken),
 
                         // File data issue - repair chunks or delete irrecoverable file
@@ -103,6 +105,11 @@ namespace SecureFolderFS.UI.ServiceImplementation
                         // Irrecoverable file - delete it
                         HealthFileDataIssueViewModel { IsRecoverable: false, File: not null } dataIssue => await HealthHelpers.DeleteIrrecoverableFileAsync(
                             dataIssue.File,
+                            cancellationToken),
+
+                        // Orphan sidecar - delete it
+                        HealthOrphanSidecarIssueViewModel => await HealthHelpers.DeleteOrphanSidecarAsync(
+                            item.Inner,
                             cancellationToken),
 
                         // Default

--- a/src/Platforms/SecureFolderFS.UI/ServiceImplementation/VaultService.cs
+++ b/src/Platforms/SecureFolderFS.UI/ServiceImplementation/VaultService.cs
@@ -25,7 +25,7 @@ namespace SecureFolderFS.UI.ServiceImplementation
         public IAsyncValidator<IFolder> VaultValidator { get; } = new VaultValidator(StreamSerializer.Instance);
 
         /// <inheritdoc/>
-        public string ShortcutFileExtension { get; } = UI.Constants.FileNames.VAULT_SHORTCUT_FILE_EXTENSION;
+        public string ShortcutFileExtension { get; } = Constants.FileNames.VAULT_SHORTCUT_FILE_EXTENSION;
 
         /// <inheritdoc/>
         public virtual bool IsNameReserved(string? name)
@@ -42,20 +42,6 @@ namespace SecureFolderFS.UI.ServiceImplementation
         {
             var vaultReader = new VaultReader(vaultFolder, StreamSerializer.Instance);
             var config = await vaultReader.ReadConfigurationAsync(cancellationToken);
-            AppPlatformVaultOptions? appPlatform = null;
-
-            if (config.AuthenticationMethod.Contains(Core.Constants.Vault.Authentication.AUTH_APP_PLATFORM, StringComparison.Ordinal))
-            {
-                try
-                {
-                    var v4Config = await vaultReader.ReadV4ConfigurationAsync(cancellationToken);
-                    appPlatform = v4Config.AppPlatform;
-                }
-                catch (Exception)
-                {
-                    appPlatform = null;
-                }
-            }
 
             return new()
             {
@@ -63,10 +49,11 @@ namespace SecureFolderFS.UI.ServiceImplementation
                 ContentCipherId = config.ContentCipherId,
                 FileNameCipherId = config.FileNameCipherId,
                 NameEncodingId = config.FileNameEncodingId,
+                ShorteningThreshold = config.ShorteningThreshold,
                 RecycleBinSize = config.RecycleBinSize,
                 VaultId = config.Uid,
                 Version = config.Version,
-                AppPlatform = appPlatform
+                AppPlatform = config.AppPlatform
             };
         }
 

--- a/src/Platforms/SecureFolderFS.UI/Strings/en-US/Resources.resx
+++ b/src/Platforms/SecureFolderFS.UI/Strings/en-US/Resources.resx
@@ -1457,4 +1457,10 @@
   <data name="LoginMethod" xml:space="preserve">
       <value>Login method</value>
   </data>
+  <data name="OrphanSidecar" xml:space="preserve">
+      <value>Unlinked shortening file</value>
+  </data>
+  <data name="DeleteOrphanSidecar" xml:space="preserve">
+      <value>The name shortening file has no data file and will be deleted.</value>
+  </data>
 </root>

--- a/src/Platforms/SecureFolderFS.UI/Strings/en-US/Resources.resx
+++ b/src/Platforms/SecureFolderFS.UI/Strings/en-US/Resources.resx
@@ -1463,4 +1463,7 @@
   <data name="DeleteOrphanSidecar" xml:space="preserve">
       <value>The name shortening file has no data file and will be deleted.</value>
   </data>
+  <data name="NameShortening" xml:space="preserve">
+      <value>Name shortening</value>
+  </data>
 </root>

--- a/src/Platforms/SecureFolderFS.UI/ViewModels/Health/HealthOrphanSidecarIssueViewModel.cs
+++ b/src/Platforms/SecureFolderFS.UI/ViewModels/Health/HealthOrphanSidecarIssueViewModel.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel;
+using OwlCore.Storage;
+using SecureFolderFS.Sdk.Enums;
+using SecureFolderFS.Sdk.ViewModels.Controls.Widgets.Health;
+using SecureFolderFS.Shared.ComponentModel;
+
+namespace SecureFolderFS.UI.ViewModels.Health
+{
+    /// <inheritdoc cref="HealthIssueViewModel"/>
+    [Bindable(true)]
+    public sealed class HealthOrphanSidecarIssueViewModel : HealthIssueViewModel
+    {
+        public HealthOrphanSidecarIssueViewModel(IStorableChild storable, IResult result, string? title = null)
+            : base(storable, result, title)
+        {
+            Severity = Severity.Warning;
+        }
+    }
+}

--- a/src/Platforms/SecureFolderFS.Uno/Views/Vault/VaultPropertiesPage.xaml
+++ b/src/Platforms/SecureFolderFS.Uno/Views/Vault/VaultPropertiesPage.xaml
@@ -38,6 +38,10 @@
                             <TextBlock Text="{l:ResourceString Rid=Security}" />
                             <TextBlock Text="{l:ResourceString Rid=DataEncryption}" />
                             <TextBlock Text="{l:ResourceString Rid=NameEncryption}" />
+                            <TextBlock
+                                x:Name="NameShorteningTitle"
+                                x:Load="{x:Bind ViewModel.FileNameShorteningText, Mode=OneWay, Converter={StaticResource NullToBoolConverter}}"
+                                Text="{l:ResourceString Rid=NameShortening}" />
                             <TextBlock Text="{l:ResourceString Rid=ActiveFileSystem}" />
                         </StackPanel>
                         <StackPanel Grid.Column="1" Spacing="4">
@@ -53,6 +57,12 @@
                                 IsTextSelectionEnabled="True"
                                 Opacity="0.6"
                                 Text="{x:Bind ViewModel.FileNameCipherText, Mode=OneWay}" />
+                            <TextBlock
+                                x:Name="NameShorteningValue"
+                                x:Load="{x:Bind ViewModel.FileNameShorteningText, Mode=OneWay, Converter={StaticResource NullToBoolConverter}}"
+                                IsTextSelectionEnabled="True"
+                                Opacity="0.6"
+                                Text="{x:Bind ViewModel.FileNameShorteningText, Mode=OneWay}" />
                             <TextBlock
                                 x:Name="FileSystemText"
                                 IsTextSelectionEnabled="True"

--- a/src/Platforms/SecureFolderFS.Uno/Views/VaultWizard/CredentialsWizardPage.xaml
+++ b/src/Platforms/SecureFolderFS.Uno/Views/VaultWizard/CredentialsWizardPage.xaml
@@ -56,6 +56,7 @@
                             <RowDefinition />
                             <RowDefinition />
                             <RowDefinition />
+                            <RowDefinition />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition />
@@ -122,6 +123,25 @@
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
+
+                        <!--  Name Shortening  -->
+                        <TextBlock
+                            Grid.Row="3"
+                            Grid.Column="0"
+                            Text="{l:ResourceString Rid=NameShortening}" />
+                        <NumberBox
+                            Grid.Row="3"
+                            Grid.Column="1"
+                            HorizontalAlignment="Right"
+                            AcceptsExpression="False"
+                            IsEnabled="{x:Bind ViewModel.IsNameCipherEnabled, Mode=OneWay}"
+                            LargeChange="10"
+                            Maximum="250"
+                            Minimum="0"
+                            SmallChange="1"
+                            SpinButtonPlacementMode="Inline"
+                            ValidationMode="InvalidInputOverwritten"
+                            Value="{x:Bind ViewModel.ShorteningThreshold, Mode=TwoWay}" />
                     </Grid>
                 </ucab:ActionBlockControl.ExpanderContent>
             </ucab:ActionBlockControl>

--- a/src/Sdk/SecureFolderFS.Sdk/ViewModels/Views/Vault/VaultPropertiesViewModel.cs
+++ b/src/Sdk/SecureFolderFS.Sdk/ViewModels/Views/Vault/VaultPropertiesViewModel.cs
@@ -23,6 +23,7 @@ namespace SecureFolderFS.Sdk.ViewModels.Views.Vault
         [ObservableProperty] private string? _SecurityText;
         [ObservableProperty] private string? _ContentCipherText;
         [ObservableProperty] private string? _FileNameCipherText;
+        [ObservableProperty] private string? _FileNameShorteningText;
         [ObservableProperty] private string? _ActiveFileSystemText;
         [ObservableProperty] private string? _FileSystemDescriptionText;
 
@@ -49,8 +50,12 @@ namespace SecureFolderFS.Sdk.ViewModels.Views.Vault
         public async Task InitAsync(CancellationToken cancellationToken = default)
         {
             var vaultOptions = await VaultService.GetVaultOptionsAsync(UnlockedVaultViewModel.VaultFolder, cancellationToken);
-            ContentCipherText = string.IsNullOrEmpty(vaultOptions.ContentCipherId) ? "NoEncryption".ToLocalized() : (vaultOptions.ContentCipherId ?? "Unknown");
-            FileNameCipherText = string.IsNullOrEmpty(vaultOptions.FileNameCipherId) ? "NoEncryption".ToLocalized() : (vaultOptions.FileNameCipherId ?? "Unknown") + $" + {vaultOptions.NameEncodingId}";
+            var areNamesEncrypted = !string.IsNullOrEmpty(vaultOptions.FileNameCipherId);
+            var areContentsEncrypted = !string.IsNullOrEmpty(vaultOptions.ContentCipherId);
+
+            ContentCipherText = !areContentsEncrypted ? "NoEncryption".ToLocalized() : (vaultOptions.ContentCipherId ?? "Unknown");
+            FileNameCipherText = !areNamesEncrypted ? "NoEncryption".ToLocalized() : (vaultOptions.FileNameCipherId ?? "Unknown") + $" + {vaultOptions.NameEncodingId}";
+            FileNameShorteningText = !areNamesEncrypted ? null : vaultOptions.ShorteningThreshold.ToString();
             ActiveFileSystemText = UnlockedVaultViewModel.StorageRoot.FileSystemName;
             FileSystemDescriptionText = UnlockedVaultViewModel.StorageRoot.Options.GetDescription();
             SecurityText = await VaultCredentialsService.FromUnlockProcedureAsync(UnlockedVaultViewModel.VaultFolder, vaultOptions.UnlockProcedure, cancellationToken);

--- a/src/Sdk/SecureFolderFS.Sdk/ViewModels/Views/Wizard/CredentialsWizardViewModel.cs
+++ b/src/Sdk/SecureFolderFS.Sdk/ViewModels/Views/Wizard/CredentialsWizardViewModel.cs
@@ -32,6 +32,7 @@ namespace SecureFolderFS.Sdk.ViewModels.Views.Wizard
         private readonly string _vaultId;
         private readonly TaskCompletionSource<IKeyUsage> _credentialsTcs;
 
+        [ObservableProperty] private int _ShorteningThreshold;
         [ObservableProperty] private bool _IsNameCipherEnabled;
         [ObservableProperty] private PickerOptionViewModel? _ContentCipher;
         [ObservableProperty] private PickerOptionViewModel? _FileNameCipher;
@@ -87,6 +88,7 @@ namespace SecureFolderFS.Sdk.ViewModels.Views.Wizard
                     ContentCipherId = ContentCipher.Id,
                     FileNameCipherId = FileNameCipher.Id,
                     NameEncodingId = EncodingOption.Id,
+                    ShorteningThreshold = Math.Max(0, Math.Min(ShorteningThreshold, 250)),
                     RecycleBinSize = 0L,
                     VaultId = _vaultId
                 };

--- a/src/Shared/SecureFolderFS.Shared/Models/VaultOptions.cs
+++ b/src/Shared/SecureFolderFS.Shared/Models/VaultOptions.cs
@@ -26,6 +26,11 @@
         public string? NameEncodingId { get; init; }
 
         /// <summary>
+        /// Gets the threshold at which the file names are shortened.
+        /// </summary>
+        public int ShorteningThreshold { get; init; }
+
+        /// <summary>
         /// Gets the size of the recycle bin.
         /// </summary>
         /// <remarks>

--- a/src/Shared/SecureFolderFS.Storage/VirtualFileSystem/VirtualFileSystemOptions.cs
+++ b/src/Shared/SecureFolderFS.Storage/VirtualFileSystem/VirtualFileSystemOptions.cs
@@ -38,6 +38,11 @@ namespace SecureFolderFS.Storage.VirtualFileSystem
         public bool IsCachingFileNames { get; protected set => SetField(ref field, value); } = true;
 
         /// <summary>
+        /// Gets or sets the threshold for shortening file names.
+        /// </summary>
+        public required int ShorteningThreshold { get; init; }
+
+        /// <summary>
         /// Sets the read-only status of the file system.
         /// </summary>
         /// <param name="value">If true, sets the file system to read-only mode; otherwise, sets it to read-write mode.</param>
@@ -85,6 +90,7 @@ namespace SecureFolderFS.Storage.VirtualFileSystem
                 IsCachingChunks = GetOption<bool?>(options, nameof(IsCachingChunks)) ?? true,
                 IsCachingFileNames = GetOption<bool?>(options, nameof(IsCachingFileNames)) ?? true,
                 IsCachingDirectoryIds = GetOption<bool?>(options, nameof(IsCachingDirectoryIds)) ?? true,
+                ShorteningThreshold = GetOption<int?>(options, nameof(ShorteningThreshold)) ?? 0,
                 RecycleBinSize = GetOption<long?>(options, nameof(RecycleBinSize)) ?? 0L
             };
         }

--- a/tests/SecureFolderFS.Tests/Helpers/MockVaultHelpers.V4.cs
+++ b/tests/SecureFolderFS.Tests/Helpers/MockVaultHelpers.V4.cs
@@ -6,28 +6,30 @@ namespace SecureFolderFS.Tests.Helpers
     internal static partial class MockVaultHelpers
     {
         // Mock recovery key
-        public const string V4_RECOVERY_KEY = "osNie57du4qOxSkuxcyYd36RsQI3xPVnUpPad/aych4=@@@7wmweOio0sGGljnvBiggxo/65ZlvTnTfVNFmwFZ7W8g=";
+        public const string V4_RECOVERY_KEY = "Ww0/Rx6XHEB87y4WWfw12xo7Xfyk67EB3FNUlWdaG/k=@@@ndVd2mEgV/9Sq9xhLKa4ZaACwQH+7JVzfb7rTLBZK2s=";
 
         private const string V4_KEYSTORE_STRING = """
                                                   {
-                                                    "c_encryptionKey": "d0qVlgnquQr1NID0IdtrTd4pqzHkGxXWhHSpkrPuYtDXjVbm3ODpwQ==",
-                                                    "c_macKey": "ZKhu3nbUjoqV6ZGtU/gitauQBuC76iCwuDnLD6oa3Pav1srYcQN/zw==",
-                                                    "salt": "OEpZjy18/dbbS+i2LlmKjA==",
-                                                    "c_softwareEntropy": "T9dHlJg4WLmuKM4Qz1rcdIn0QsCdiGNNtU6EyzN03OA=",
-                                                    "entropyNonce": "buZqCJGGsukm87mP",
-                                                    "entropyTag": "AvsZawlWTMG3gBpuavmu4g=="
+                                                    "c_encryptionKey": "wALUX7wq5cZ45yB3HncCiiXZ3OiQmOTZj5MU/T03dxldD3pyh11C5g==",
+                                                    "c_macKey": "1DrsQmRH4X6CgM08aRqeANYXxN6NWlNrzsbp6DKeXErrE+KfYRS08g==",
+                                                    "salt": "e5nJCCu+uJZ3uAwio+iXOg==",
+                                                    "c_softwareEntropy": "bYWy61+0lXUb8e9ZLmasECuCZWmUTaKC8BIJvEofix4=",
+                                                    "entropyNonce": "jzd/bdatTE2uOoMa",
+                                                    "entropyTag": "OwjR5RFBmvl7Aaf0rwQ8yw=="
                                                   }
                                                   """;
 
         private const string V4_SFCONFIG_STRING = """
                                                   {
-                                                    "contentCipherScheme": "XChaCha20-Poly1305",
+                                                    "contentCipherScheme": "AES-GCM",
                                                     "filenameCipherScheme": "AES-SIV",
                                                     "filenameEncoding": "Base4K",
-                                                    "recycleBinSize": -1,
+                                                    "filenameShortening": 0,
+                                                    "recycleBinSize": 0,
                                                     "authMode": "password",
-                                                    "vaultId": "8a1fbf8a-b986-4f8a-a3d7-59df8d203e3a",
-                                                    "hmacsha256mac": "/gLIyGTCd8Y/bvj3YxY7JmmFEbCX3iDGYFVmeNMNw8w=",
+                                                    "vaultId": "0b47eb66-1e58-451f-a72f-f1f5b34295b6",
+                                                    "appPlatform": null,
+                                                    "hmacsha256mac": "fpSCs1rfVwtWeCikRcSeJimORlfN3f+MCjed9nobofA=",
                                                     "version": 4
                                                   }
                                                   """;


### PR DESCRIPTION
## Tasklist
- [x] [Recycle Bin] Write sidecar files when recovering from the Recycle Bin
- [x] [Other] Implement shortening for NativePathHelpers
- [x] [Other] Detect correct shortening threshold when restoring vaults.
- [x] [FS] Implement shortening in Dokany
- [x] [FS] Implement shortening in WinFsp
- [x] [FS] Implement shortening in FUSE
- [x] [Health] Detect and delete orphan sidecar files
- [x] [Health] Re-adjust fixing broken names to use sidecars when applicable